### PR TITLE
Add shader compilation diagnostics and resident preloading

### DIFF
--- a/core/bind/core_bind.cpp
+++ b/core/bind/core_bind.cpp
@@ -3286,6 +3286,14 @@ bool _Engine::is_shader_program_residency_enabled() const {
 	return Engine::get_singleton()->is_shader_program_residency_enabled();
 }
 
+void _Engine::set_shader_program_residency_owner(const String &p_owner) {
+	Engine::get_singleton()->set_shader_program_residency_owner(p_owner);
+}
+
+String _Engine::get_shader_program_residency_owner() const {
+	return Engine::get_singleton()->get_shader_program_residency_owner();
+}
+
 uint32_t _Engine::get_shader_resident_program_count() const {
 	return Engine::get_singleton()->get_shader_resident_program_count();
 }
@@ -3347,6 +3355,8 @@ void _Engine::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("is_shader_compilation_tracking_enabled"), &_Engine::is_shader_compilation_tracking_enabled);
 	ClassDB::bind_method(D_METHOD("set_shader_program_residency_enabled", "enabled"), &_Engine::set_shader_program_residency_enabled);
 	ClassDB::bind_method(D_METHOD("is_shader_program_residency_enabled"), &_Engine::is_shader_program_residency_enabled);
+	ClassDB::bind_method(D_METHOD("set_shader_program_residency_owner", "owner"), &_Engine::set_shader_program_residency_owner);
+	ClassDB::bind_method(D_METHOD("get_shader_program_residency_owner"), &_Engine::get_shader_program_residency_owner);
 	ClassDB::bind_method(D_METHOD("get_shader_resident_program_count"), &_Engine::get_shader_resident_program_count);
 	ClassDB::bind_method(D_METHOD("drain_shader_compilation_events"), &_Engine::drain_shader_compilation_events);
 	ClassDB::bind_method(D_METHOD("clear_shader_compilation_events"), &_Engine::clear_shader_compilation_events);

--- a/core/bind/core_bind.cpp
+++ b/core/bind/core_bind.cpp
@@ -3286,6 +3286,14 @@ void _Engine::clear_shader_compilation_events() {
 	Engine::get_singleton()->clear_shader_compilation_events();
 }
 
+void _Engine::set_shader_compilation_debug_targets(const PoolStringArray &p_targets) {
+	Engine::get_singleton()->set_shader_compilation_debug_targets(p_targets);
+}
+
+PoolStringArray _Engine::get_shader_compilation_debug_targets() const {
+	return Engine::get_singleton()->get_shader_compilation_debug_targets();
+}
+
 void _Engine::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_iterations_per_second", "iterations_per_second"), &_Engine::set_iterations_per_second);
 	ClassDB::bind_method(D_METHOD("get_iterations_per_second"), &_Engine::get_iterations_per_second);
@@ -3327,6 +3335,8 @@ void _Engine::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("is_shader_compilation_tracking_enabled"), &_Engine::is_shader_compilation_tracking_enabled);
 	ClassDB::bind_method(D_METHOD("drain_shader_compilation_events"), &_Engine::drain_shader_compilation_events);
 	ClassDB::bind_method(D_METHOD("clear_shader_compilation_events"), &_Engine::clear_shader_compilation_events);
+	ClassDB::bind_method(D_METHOD("set_shader_compilation_debug_targets", "targets"), &_Engine::set_shader_compilation_debug_targets);
+	ClassDB::bind_method(D_METHOD("get_shader_compilation_debug_targets"), &_Engine::get_shader_compilation_debug_targets);
 
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "editor_hint"), "set_editor_hint", "is_editor_hint");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "print_error_messages"), "set_print_error_messages", "is_printing_error_messages");

--- a/core/bind/core_bind.cpp
+++ b/core/bind/core_bind.cpp
@@ -3270,6 +3270,22 @@ bool _Engine::is_printing_error_messages() const {
 	return Engine::get_singleton()->is_printing_error_messages();
 }
 
+void _Engine::set_shader_compilation_tracking_enabled(bool p_enabled) {
+	Engine::get_singleton()->set_shader_compilation_tracking_enabled(p_enabled);
+}
+
+bool _Engine::is_shader_compilation_tracking_enabled() const {
+	return Engine::get_singleton()->is_shader_compilation_tracking_enabled();
+}
+
+Array _Engine::drain_shader_compilation_events() {
+	return Engine::get_singleton()->drain_shader_compilation_events();
+}
+
+void _Engine::clear_shader_compilation_events() {
+	Engine::get_singleton()->clear_shader_compilation_events();
+}
+
 void _Engine::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_iterations_per_second", "iterations_per_second"), &_Engine::set_iterations_per_second);
 	ClassDB::bind_method(D_METHOD("get_iterations_per_second"), &_Engine::get_iterations_per_second);
@@ -3306,6 +3322,11 @@ void _Engine::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("set_print_error_messages", "enabled"), &_Engine::set_print_error_messages);
 	ClassDB::bind_method(D_METHOD("is_printing_error_messages"), &_Engine::is_printing_error_messages);
+
+	ClassDB::bind_method(D_METHOD("set_shader_compilation_tracking_enabled", "enabled"), &_Engine::set_shader_compilation_tracking_enabled);
+	ClassDB::bind_method(D_METHOD("is_shader_compilation_tracking_enabled"), &_Engine::is_shader_compilation_tracking_enabled);
+	ClassDB::bind_method(D_METHOD("drain_shader_compilation_events"), &_Engine::drain_shader_compilation_events);
+	ClassDB::bind_method(D_METHOD("clear_shader_compilation_events"), &_Engine::clear_shader_compilation_events);
 
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "editor_hint"), "set_editor_hint", "is_editor_hint");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "print_error_messages"), "set_print_error_messages", "is_printing_error_messages");

--- a/core/bind/core_bind.cpp
+++ b/core/bind/core_bind.cpp
@@ -3278,6 +3278,18 @@ bool _Engine::is_shader_compilation_tracking_enabled() const {
 	return Engine::get_singleton()->is_shader_compilation_tracking_enabled();
 }
 
+void _Engine::set_shader_program_residency_enabled(bool p_enabled) {
+	Engine::get_singleton()->set_shader_program_residency_enabled(p_enabled);
+}
+
+bool _Engine::is_shader_program_residency_enabled() const {
+	return Engine::get_singleton()->is_shader_program_residency_enabled();
+}
+
+uint32_t _Engine::get_shader_resident_program_count() const {
+	return Engine::get_singleton()->get_shader_resident_program_count();
+}
+
 Array _Engine::drain_shader_compilation_events() {
 	return Engine::get_singleton()->drain_shader_compilation_events();
 }
@@ -3333,6 +3345,9 @@ void _Engine::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("set_shader_compilation_tracking_enabled", "enabled"), &_Engine::set_shader_compilation_tracking_enabled);
 	ClassDB::bind_method(D_METHOD("is_shader_compilation_tracking_enabled"), &_Engine::is_shader_compilation_tracking_enabled);
+	ClassDB::bind_method(D_METHOD("set_shader_program_residency_enabled", "enabled"), &_Engine::set_shader_program_residency_enabled);
+	ClassDB::bind_method(D_METHOD("is_shader_program_residency_enabled"), &_Engine::is_shader_program_residency_enabled);
+	ClassDB::bind_method(D_METHOD("get_shader_resident_program_count"), &_Engine::get_shader_resident_program_count);
 	ClassDB::bind_method(D_METHOD("drain_shader_compilation_events"), &_Engine::drain_shader_compilation_events);
 	ClassDB::bind_method(D_METHOD("clear_shader_compilation_events"), &_Engine::clear_shader_compilation_events);
 	ClassDB::bind_method(D_METHOD("set_shader_compilation_debug_targets", "targets"), &_Engine::set_shader_compilation_debug_targets);

--- a/core/bind/core_bind.h
+++ b/core/bind/core_bind.h
@@ -860,6 +860,8 @@ public:
 	bool is_shader_compilation_tracking_enabled() const;
 	void set_shader_program_residency_enabled(bool p_enabled);
 	bool is_shader_program_residency_enabled() const;
+	void set_shader_program_residency_owner(const String &p_owner);
+	String get_shader_program_residency_owner() const;
 	uint32_t get_shader_resident_program_count() const;
 	Array drain_shader_compilation_events();
 	void clear_shader_compilation_events();

--- a/core/bind/core_bind.h
+++ b/core/bind/core_bind.h
@@ -858,6 +858,9 @@ public:
 
 	void set_shader_compilation_tracking_enabled(bool p_enabled);
 	bool is_shader_compilation_tracking_enabled() const;
+	void set_shader_program_residency_enabled(bool p_enabled);
+	bool is_shader_program_residency_enabled() const;
+	uint32_t get_shader_resident_program_count() const;
 	Array drain_shader_compilation_events();
 	void clear_shader_compilation_events();
 	void set_shader_compilation_debug_targets(const PoolStringArray &p_targets);

--- a/core/bind/core_bind.h
+++ b/core/bind/core_bind.h
@@ -856,6 +856,11 @@ public:
 	void set_print_error_messages(bool p_enabled);
 	bool is_printing_error_messages() const;
 
+	void set_shader_compilation_tracking_enabled(bool p_enabled);
+	bool is_shader_compilation_tracking_enabled() const;
+	Array drain_shader_compilation_events();
+	void clear_shader_compilation_events();
+
 	_Engine();
 };
 

--- a/core/bind/core_bind.h
+++ b/core/bind/core_bind.h
@@ -860,6 +860,8 @@ public:
 	bool is_shader_compilation_tracking_enabled() const;
 	Array drain_shader_compilation_events();
 	void clear_shader_compilation_events();
+	void set_shader_compilation_debug_targets(const PoolStringArray &p_targets);
+	PoolStringArray get_shader_compilation_debug_targets() const;
 
 	_Engine();
 };

--- a/core/engine.cpp
+++ b/core/engine.cpp
@@ -50,6 +50,7 @@ Engine::ShaderCompilationEvent::ShaderCompilationEvent() {
 	cache_eligible = false;
 	cache_lookup_attempted = false;
 	cache_hit = false;
+	resident_program_hit = false;
 	success = true;
 }
 
@@ -266,6 +267,7 @@ Array Engine::drain_shader_compilation_events() {
 		item["cache_eligible"] = event.cache_eligible;
 		item["cache_lookup_attempted"] = event.cache_lookup_attempted;
 		item["cache_hit"] = event.cache_hit;
+		item["resident_program_hit"] = event.resident_program_hit;
 		item["program_cache_key"] = event.program_cache_key;
 		item["vertex_source_hash"] = event.vertex_source_hash;
 		item["fragment_source_hash"] = event.fragment_source_hash;

--- a/core/engine.cpp
+++ b/core/engine.cpp
@@ -231,6 +231,16 @@ bool Engine::is_shader_program_residency_enabled() const {
 	return shader_program_residency_enabled.is_set();
 }
 
+void Engine::set_shader_program_residency_owner(const String &p_owner) {
+	MutexLock lock(shader_program_residency_owner_mutex);
+	shader_program_residency_owner = p_owner;
+}
+
+String Engine::get_shader_program_residency_owner() const {
+	MutexLock lock(shader_program_residency_owner_mutex);
+	return shader_program_residency_owner;
+}
+
 uint32_t Engine::get_shader_resident_program_count() const {
 	return shader_resident_program_count.get();
 }
@@ -408,6 +418,7 @@ Engine::Engine() {
 	shader_compilation_sequence.set(0);
 	shader_program_residency_enabled.clear();
 	shader_resident_program_count.set(0);
+	shader_program_residency_owner = String();
 	_portals_active = false;
 	_occlusion_culling_active = false;
 }

--- a/core/engine.cpp
+++ b/core/engine.cpp
@@ -223,6 +223,27 @@ bool Engine::is_shader_compilation_tracking_enabled() const {
 	return shader_compilation_tracking_enabled.is_set();
 }
 
+void Engine::set_shader_program_residency_enabled(bool p_enabled) {
+	shader_program_residency_enabled.set_to(p_enabled);
+}
+
+bool Engine::is_shader_program_residency_enabled() const {
+	return shader_program_residency_enabled.is_set();
+}
+
+uint32_t Engine::get_shader_resident_program_count() const {
+	return shader_resident_program_count.get();
+}
+
+void Engine::notify_shader_program_retained() {
+	shader_resident_program_count.increment();
+}
+
+void Engine::notify_shader_program_released() {
+	ERR_FAIL_COND(shader_resident_program_count.get() == 0);
+	shader_resident_program_count.decrement();
+}
+
 uint64_t Engine::record_shader_compilation_event(const ShaderCompilationEvent &p_event) {
 	if (!shader_compilation_tracking_enabled.is_set()) {
 		return 0;
@@ -385,6 +406,8 @@ Engine::Engine() {
 	editor_hint = false;
 	shader_compilation_tracking_enabled.clear();
 	shader_compilation_sequence.set(0);
+	shader_program_residency_enabled.clear();
+	shader_resident_program_count.set(0);
 	_portals_active = false;
 	_occlusion_culling_active = false;
 }

--- a/core/engine.cpp
+++ b/core/engine.cpp
@@ -45,6 +45,11 @@ Engine::ShaderCompilationEvent::ShaderCompilationEvent() {
 	render_frame = 0;
 	variant = 0;
 	custom_code_id = 0;
+	custom_code_version = 0;
+	debug_target = false;
+	cache_eligible = false;
+	cache_lookup_attempted = false;
+	cache_hit = false;
 	success = true;
 }
 
@@ -249,6 +254,7 @@ Array Engine::drain_shader_compilation_events() {
 		item["render_frame"] = event.render_frame;
 		item["variant"] = event.variant;
 		item["custom_code_id"] = event.custom_code_id;
+		item["custom_code_version"] = event.custom_code_version;
 		item["phase"] = event.phase;
 		item["operation"] = event.operation;
 		item["backend"] = event.backend;
@@ -256,6 +262,29 @@ Array Engine::drain_shader_compilation_events() {
 		item["source"] = event.source;
 		item["shader_name"] = event.shader_name;
 		item["material_path"] = event.material_path;
+		item["debug_target"] = event.debug_target;
+		item["cache_eligible"] = event.cache_eligible;
+		item["cache_lookup_attempted"] = event.cache_lookup_attempted;
+		item["cache_hit"] = event.cache_hit;
+		item["program_cache_key"] = event.program_cache_key;
+		item["vertex_source_hash"] = event.vertex_source_hash;
+		item["fragment_source_hash"] = event.fragment_source_hash;
+		Array enabled_conditionals;
+		for (int j = 0; j < event.enabled_conditionals.size(); j++) {
+			enabled_conditionals.push_back(event.enabled_conditionals[j]);
+		}
+		item["enabled_conditionals"] = enabled_conditionals;
+		Array custom_defines;
+		for (int j = 0; j < event.custom_defines.size(); j++) {
+			custom_defines.push_back(event.custom_defines[j]);
+		}
+		item["custom_defines"] = custom_defines;
+		if (!event.generated_vertex_source.empty()) {
+			item["generated_vertex_source"] = event.generated_vertex_source;
+		}
+		if (!event.generated_fragment_source.empty()) {
+			item["generated_fragment_source"] = event.generated_fragment_source;
+		}
 		item["success"] = event.success;
 		result[i] = item;
 	}
@@ -266,6 +295,46 @@ Array Engine::drain_shader_compilation_events() {
 void Engine::clear_shader_compilation_events() {
 	MutexLock lock(shader_compilation_events_mutex);
 	shader_compilation_events.clear();
+}
+
+void Engine::set_shader_compilation_debug_targets(const PoolStringArray &p_targets) {
+	Vector<String> normalized_targets;
+	PoolStringArray::Read targets = p_targets.read();
+	for (int i = 0; i < p_targets.size(); i++) {
+		String target = targets[i].strip_edges().replace("\\", "/");
+		if (!target.empty() && normalized_targets.find(target) == -1) {
+			normalized_targets.push_back(target);
+		}
+	}
+
+	MutexLock lock(shader_compilation_debug_targets_mutex);
+	shader_compilation_debug_targets = normalized_targets;
+}
+
+PoolStringArray Engine::get_shader_compilation_debug_targets() const {
+	PoolStringArray result;
+	MutexLock lock(shader_compilation_debug_targets_mutex);
+	for (int i = 0; i < shader_compilation_debug_targets.size(); i++) {
+		result.push_back(shader_compilation_debug_targets[i]);
+	}
+	return result;
+}
+
+bool Engine::is_shader_compilation_debug_target(const String &p_material_path) const {
+	String material_path = p_material_path.replace("\\", "/");
+	String material_file = material_path.get_file().get_slice("::", 0);
+
+	MutexLock lock(shader_compilation_debug_targets_mutex);
+	for (int i = 0; i < shader_compilation_debug_targets.size(); i++) {
+		const String &target = shader_compilation_debug_targets[i];
+		if (material_path == target || material_path.begins_with(target + "::")) {
+			return true;
+		}
+		if (target.find("/") == -1 && material_file == target) {
+			return true;
+		}
+	}
+	return false;
 }
 
 void Engine::add_singleton(const Singleton &p_singleton) {

--- a/core/engine.cpp
+++ b/core/engine.cpp
@@ -35,6 +35,19 @@
 #include "core/license.gen.h"
 #include "core/version.h"
 
+static const int MAX_QUEUED_SHADER_COMPILATION_EVENTS = 4096;
+
+Engine::ShaderCompilationEvent::ShaderCompilationEvent() {
+	compilation_id = 0;
+	timestamp_usec = 0;
+	duration_usec = 0;
+	idle_frame = 0;
+	render_frame = 0;
+	variant = 0;
+	custom_code_id = 0;
+	success = true;
+}
+
 void Engine::set_iterations_per_second(int p_ips) {
 	ERR_FAIL_COND_MSG(p_ips <= 0, "Engine iterations per second must be greater than 0.");
 	ips = p_ips;
@@ -191,6 +204,70 @@ bool Engine::is_printing_error_messages() const {
 	return _print_error_enabled;
 }
 
+void Engine::set_shader_compilation_tracking_enabled(bool p_enabled) {
+	if (shader_compilation_tracking_enabled.is_set() == p_enabled) {
+		return;
+	}
+
+	shader_compilation_tracking_enabled.set_to(p_enabled);
+	clear_shader_compilation_events();
+}
+
+bool Engine::is_shader_compilation_tracking_enabled() const {
+	return shader_compilation_tracking_enabled.is_set();
+}
+
+uint64_t Engine::record_shader_compilation_event(const ShaderCompilationEvent &p_event) {
+	if (!shader_compilation_tracking_enabled.is_set()) {
+		return 0;
+	}
+
+	ShaderCompilationEvent event = p_event;
+	if (event.compilation_id == 0) {
+		event.compilation_id = shader_compilation_sequence.increment();
+	}
+
+	MutexLock lock(shader_compilation_events_mutex);
+	if (shader_compilation_events.size() >= MAX_QUEUED_SHADER_COMPILATION_EVENTS) {
+		shader_compilation_events.remove(0);
+	}
+	shader_compilation_events.push_back(event);
+	return event.compilation_id;
+}
+
+Array Engine::drain_shader_compilation_events() {
+	Array result;
+	MutexLock lock(shader_compilation_events_mutex);
+	result.resize(shader_compilation_events.size());
+	for (int i = 0; i < shader_compilation_events.size(); i++) {
+		const ShaderCompilationEvent &event = shader_compilation_events[i];
+		Dictionary item;
+		item["compilation_id"] = event.compilation_id;
+		item["timestamp_usec"] = event.timestamp_usec;
+		item["duration_usec"] = event.duration_usec;
+		item["idle_frame"] = event.idle_frame;
+		item["render_frame"] = event.render_frame;
+		item["variant"] = event.variant;
+		item["custom_code_id"] = event.custom_code_id;
+		item["phase"] = event.phase;
+		item["operation"] = event.operation;
+		item["backend"] = event.backend;
+		item["compilation_mode"] = event.compilation_mode;
+		item["source"] = event.source;
+		item["shader_name"] = event.shader_name;
+		item["material_path"] = event.material_path;
+		item["success"] = event.success;
+		result[i] = item;
+	}
+	shader_compilation_events.clear();
+	return result;
+}
+
+void Engine::clear_shader_compilation_events() {
+	MutexLock lock(shader_compilation_events_mutex);
+	shader_compilation_events.clear();
+}
+
 void Engine::add_singleton(const Singleton &p_singleton) {
 	singletons.push_back(p_singleton);
 	singleton_ptrs[p_singleton.name] = p_singleton.ptr;
@@ -235,6 +312,8 @@ Engine::Engine() {
 	_frame_ticks = 0;
 	_frame_step = 0;
 	editor_hint = false;
+	shader_compilation_tracking_enabled.clear();
+	shader_compilation_sequence.set(0);
 	_portals_active = false;
 	_occlusion_culling_active = false;
 }

--- a/core/engine.h
+++ b/core/engine.h
@@ -48,6 +48,7 @@ public:
 		uint64_t render_frame;
 		uint64_t variant;
 		uint32_t custom_code_id;
+		uint32_t custom_code_version;
 		String phase;
 		String operation;
 		String backend;
@@ -55,6 +56,17 @@ public:
 		String source;
 		String shader_name;
 		String material_path;
+		String program_cache_key;
+		String vertex_source_hash;
+		String fragment_source_hash;
+		String generated_vertex_source;
+		String generated_fragment_source;
+		Vector<String> enabled_conditionals;
+		Vector<String> custom_defines;
+		bool debug_target;
+		bool cache_eligible;
+		bool cache_lookup_attempted;
+		bool cache_hit;
 		bool success;
 
 		ShaderCompilationEvent();
@@ -97,6 +109,8 @@ private:
 	SafeNumeric<uint64_t> shader_compilation_sequence;
 	Mutex shader_compilation_events_mutex;
 	Vector<ShaderCompilationEvent> shader_compilation_events;
+	mutable Mutex shader_compilation_debug_targets_mutex;
+	Vector<String> shader_compilation_debug_targets;
 
 	static Engine *singleton;
 
@@ -137,6 +151,9 @@ public:
 	uint64_t record_shader_compilation_event(const ShaderCompilationEvent &p_event);
 	Array drain_shader_compilation_events();
 	void clear_shader_compilation_events();
+	void set_shader_compilation_debug_targets(const PoolStringArray &p_targets);
+	PoolStringArray get_shader_compilation_debug_targets() const;
+	bool is_shader_compilation_debug_target(const String &p_material_path) const;
 
 	void add_singleton(const Singleton &p_singleton);
 	void get_singletons(List<Singleton> *p_singletons);

--- a/core/engine.h
+++ b/core/engine.h
@@ -67,6 +67,7 @@ public:
 		bool cache_eligible;
 		bool cache_lookup_attempted;
 		bool cache_hit;
+		bool resident_program_hit;
 		bool success;
 
 		ShaderCompilationEvent();

--- a/core/engine.h
+++ b/core/engine.h
@@ -33,11 +33,33 @@
 
 #include "core/list.h"
 #include "core/os/main_loop.h"
+#include "core/os/mutex.h"
+#include "core/safe_refcount.h"
 #include "core/ustring.h"
 #include "core/vector.h"
 
 class Engine {
 public:
+	struct ShaderCompilationEvent {
+		uint64_t compilation_id;
+		uint64_t timestamp_usec;
+		uint64_t duration_usec;
+		uint64_t idle_frame;
+		uint64_t render_frame;
+		uint64_t variant;
+		uint32_t custom_code_id;
+		String phase;
+		String operation;
+		String backend;
+		String compilation_mode;
+		String source;
+		String shader_name;
+		String material_path;
+		bool success;
+
+		ShaderCompilationEvent();
+	};
+
 	struct Singleton {
 		StringName name;
 		Object *ptr;
@@ -70,6 +92,11 @@ private:
 	Map<StringName, Object *> singleton_ptrs;
 
 	bool editor_hint;
+
+	SafeFlag shader_compilation_tracking_enabled;
+	SafeNumeric<uint64_t> shader_compilation_sequence;
+	Mutex shader_compilation_events_mutex;
+	Vector<ShaderCompilationEvent> shader_compilation_events;
 
 	static Engine *singleton;
 
@@ -104,6 +131,12 @@ public:
 
 	void set_print_error_messages(bool p_enabled);
 	bool is_printing_error_messages() const;
+
+	void set_shader_compilation_tracking_enabled(bool p_enabled);
+	bool is_shader_compilation_tracking_enabled() const;
+	uint64_t record_shader_compilation_event(const ShaderCompilationEvent &p_event);
+	Array drain_shader_compilation_events();
+	void clear_shader_compilation_events();
 
 	void add_singleton(const Singleton &p_singleton);
 	void get_singletons(List<Singleton> *p_singletons);

--- a/core/engine.h
+++ b/core/engine.h
@@ -110,6 +110,8 @@ private:
 	SafeNumeric<uint64_t> shader_compilation_sequence;
 	SafeFlag shader_program_residency_enabled;
 	SafeNumeric<uint32_t> shader_resident_program_count;
+	mutable Mutex shader_program_residency_owner_mutex;
+	String shader_program_residency_owner;
 	Mutex shader_compilation_events_mutex;
 	Vector<ShaderCompilationEvent> shader_compilation_events;
 	mutable Mutex shader_compilation_debug_targets_mutex;
@@ -153,6 +155,8 @@ public:
 	bool is_shader_compilation_tracking_enabled() const;
 	void set_shader_program_residency_enabled(bool p_enabled);
 	bool is_shader_program_residency_enabled() const;
+	void set_shader_program_residency_owner(const String &p_owner);
+	String get_shader_program_residency_owner() const;
 	uint32_t get_shader_resident_program_count() const;
 	void notify_shader_program_retained();
 	void notify_shader_program_released();

--- a/core/engine.h
+++ b/core/engine.h
@@ -108,6 +108,8 @@ private:
 
 	SafeFlag shader_compilation_tracking_enabled;
 	SafeNumeric<uint64_t> shader_compilation_sequence;
+	SafeFlag shader_program_residency_enabled;
+	SafeNumeric<uint32_t> shader_resident_program_count;
 	Mutex shader_compilation_events_mutex;
 	Vector<ShaderCompilationEvent> shader_compilation_events;
 	mutable Mutex shader_compilation_debug_targets_mutex;
@@ -149,6 +151,11 @@ public:
 
 	void set_shader_compilation_tracking_enabled(bool p_enabled);
 	bool is_shader_compilation_tracking_enabled() const;
+	void set_shader_program_residency_enabled(bool p_enabled);
+	bool is_shader_program_residency_enabled() const;
+	uint32_t get_shader_resident_program_count() const;
+	void notify_shader_program_retained();
+	void notify_shader_program_released();
 	uint64_t record_shader_compilation_event(const ShaderCompilationEvent &p_event);
 	Array drain_shader_compilation_events();
 	void clear_shader_compilation_events();

--- a/drivers/dummy/rasterizer_dummy.h
+++ b/drivers/dummy/rasterizer_dummy.h
@@ -274,6 +274,7 @@ public:
 
 	RID material_create() { return RID(); }
 
+	void material_set_path(RID p_material, const String &p_path) {}
 	void material_set_render_priority(RID p_material, int priority) {}
 	void material_set_shader(RID p_shader_material, RID p_shader) {}
 	RID material_get_shader(RID p_shader_material) const { return RID(); }

--- a/drivers/gles2/rasterizer_storage_gles2.cpp
+++ b/drivers/gles2/rasterizer_storage_gles2.cpp
@@ -1784,6 +1784,12 @@ RID RasterizerStorageGLES2::material_create() {
 	return material_owner.make_rid(material);
 }
 
+void RasterizerStorageGLES2::material_set_path(RID p_material, const String &p_path) {
+	Material *material = material_owner.get(p_material);
+	ERR_FAIL_COND(!material);
+	material->path = p_path;
+}
+
 void RasterizerStorageGLES2::material_set_shader(RID p_material, RID p_shader) {
 	Material *material = material_owner.get(p_material);
 	ERR_FAIL_COND(!material);

--- a/drivers/gles2/rasterizer_storage_gles2.h
+++ b/drivers/gles2/rasterizer_storage_gles2.h
@@ -560,6 +560,7 @@ public:
 
 	struct Material : public RID_Data {
 		Shader *shader;
+		String path;
 		Map<StringName, Variant> params;
 		SelfList<Material> list;
 		SelfList<Material> dirty_list;
@@ -602,6 +603,7 @@ public:
 
 	virtual RID material_create();
 
+	virtual void material_set_path(RID p_material, const String &p_path);
 	virtual void material_set_shader(RID p_material, RID p_shader);
 	virtual RID material_get_shader(RID p_material) const;
 

--- a/drivers/gles3/rasterizer_canvas_gles3.cpp
+++ b/drivers/gles3/rasterizer_canvas_gles3.cpp
@@ -173,7 +173,7 @@ void RasterizerCanvasGLES3::_legacy_canvas_render_item(Item *p_ci, RenderItemSta
 					VisualServerRaster::redraw_request(false);
 				}
 
-				state.canvas_shader.set_custom_shader(shader_ptr->custom_code_id);
+				state.canvas_shader.set_custom_shader(shader_ptr->custom_code_id, material_ptr->path);
 				state.canvas_shader.bind();
 			}
 
@@ -1260,7 +1260,7 @@ void RasterizerCanvasGLES3::render_joined_item(const BItemJoined &p_bij, RenderI
 					VisualServerRaster::redraw_request(false);
 				}
 
-				state.canvas_shader.set_custom_shader(shader_ptr->custom_code_id);
+				state.canvas_shader.set_custom_shader(shader_ptr->custom_code_id, material_ptr->path);
 				state.canvas_shader.bind();
 			}
 

--- a/drivers/gles3/rasterizer_gles3.cpp
+++ b/drivers/gles3/rasterizer_gles3.cpp
@@ -84,6 +84,48 @@ Dictionary RasterizerGLES3::shader_precompile_internal_variant(const String &p_s
 	return result;
 }
 
+Dictionary RasterizerGLES3::shader_release_resident_program_owner(const String &p_owner) {
+	ShaderGLES3 *internal_shaders[] = {
+		&storage->shaders.copy,
+		&storage->shaders.cubemap_filter,
+		&storage->shaders.blend_shapes,
+		&storage->shaders.particles,
+		&scene->state.scene_shader,
+		&scene->state.cube_to_dp_shader,
+		&scene->state.resolve_shader,
+		&scene->state.ssr_shader,
+		&scene->state.effect_blur_shader,
+		&scene->state.sss_shader,
+		&scene->state.ssao_minify_shader,
+		&scene->state.ssao_shader,
+		&scene->state.ssao_blur_shader,
+		&scene->state.exposure_shader,
+		&scene->state.tonemap_shader,
+		&canvas->state.canvas_shader,
+		&canvas->state.canvas_shadow_shader,
+		&canvas->state.lens_shader,
+	};
+
+	uint32_t programs_released = 0;
+	uint32_t versions_invalidated = 0;
+	for (uint32_t i = 0; i < sizeof(internal_shaders) / sizeof(internal_shaders[0]); i++) {
+		Dictionary shader_result = internal_shaders[i]->release_resident_program_owner(p_owner);
+		if (!(bool)shader_result["success"]) {
+			return shader_result;
+		}
+		programs_released += (uint32_t)(int)shader_result["programs_released"];
+		versions_invalidated += (uint32_t)(int)shader_result["versions_invalidated"];
+	}
+
+	Dictionary result;
+	result["success"] = true;
+	result["owner"] = p_owner;
+	result["programs_released"] = programs_released;
+	result["versions_invalidated"] = versions_invalidated;
+	result["resident_program_count"] = Engine::get_singleton()->get_shader_resident_program_count();
+	return result;
+}
+
 #define _EXT_DEBUG_OUTPUT_SYNCHRONOUS_ARB 0x8242
 #define _EXT_DEBUG_NEXT_LOGGED_MESSAGE_LENGTH_ARB 0x8243
 #define _EXT_DEBUG_CALLBACK_FUNCTION_ARB 0x8244

--- a/drivers/gles3/rasterizer_gles3.cpp
+++ b/drivers/gles3/rasterizer_gles3.cpp
@@ -45,6 +45,45 @@ RasterizerScene *RasterizerGLES3::get_scene() {
 	return scene;
 }
 
+Dictionary RasterizerGLES3::shader_precompile_internal_variant(const String &p_shader_name, const PoolStringArray &p_enabled_conditionals) {
+	ShaderGLES3 *internal_shaders[] = {
+		&storage->shaders.copy,
+		&storage->shaders.cubemap_filter,
+		&storage->shaders.blend_shapes,
+		&storage->shaders.particles,
+		&scene->state.scene_shader,
+		&scene->state.cube_to_dp_shader,
+		&scene->state.resolve_shader,
+		&scene->state.ssr_shader,
+		&scene->state.effect_blur_shader,
+		&scene->state.sss_shader,
+		&scene->state.ssao_minify_shader,
+		&scene->state.ssao_shader,
+		&scene->state.ssao_blur_shader,
+		&scene->state.exposure_shader,
+		&scene->state.tonemap_shader,
+		&canvas->state.canvas_shader,
+		&canvas->state.canvas_shadow_shader,
+		&canvas->state.lens_shader,
+	};
+
+	PoolStringArray available_shader_names;
+	for (uint32_t i = 0; i < sizeof(internal_shaders) / sizeof(internal_shaders[0]); i++) {
+		const String shader_name = internal_shaders[i]->get_public_shader_name();
+		available_shader_names.append(shader_name);
+		if (shader_name == p_shader_name) {
+			return internal_shaders[i]->precompile_custom_shader_variant(ShaderGLES3::CUSTOM_SHADER_DISABLED, p_enabled_conditionals);
+		}
+	}
+
+	Dictionary result;
+	result["success"] = false;
+	result["error"] = "unknown_internal_shader";
+	result["shader_name"] = p_shader_name;
+	result["available_shader_names"] = available_shader_names;
+	return result;
+}
+
 #define _EXT_DEBUG_OUTPUT_SYNCHRONOUS_ARB 0x8242
 #define _EXT_DEBUG_NEXT_LOGGED_MESSAGE_LENGTH_ARB 0x8243
 #define _EXT_DEBUG_CALLBACK_FUNCTION_ARB 0x8244

--- a/drivers/gles3/rasterizer_gles3.h
+++ b/drivers/gles3/rasterizer_gles3.h
@@ -51,6 +51,7 @@ public:
 	virtual RasterizerCanvas *get_canvas();
 	virtual RasterizerScene *get_scene();
 	virtual Dictionary shader_precompile_internal_variant(const String &p_shader_name, const PoolStringArray &p_enabled_conditionals);
+	virtual Dictionary shader_release_resident_program_owner(const String &p_owner);
 
 	virtual void set_boot_image(const Ref<Image> &p_image, const Color &p_color, bool p_scale, bool p_use_filter = true);
 	virtual void set_shader_time_scale(float p_scale);

--- a/drivers/gles3/rasterizer_gles3.h
+++ b/drivers/gles3/rasterizer_gles3.h
@@ -50,6 +50,7 @@ public:
 	virtual RasterizerStorage *get_storage();
 	virtual RasterizerCanvas *get_canvas();
 	virtual RasterizerScene *get_scene();
+	virtual Dictionary shader_precompile_internal_variant(const String &p_shader_name, const PoolStringArray &p_enabled_conditionals);
 
 	virtual void set_boot_image(const Ref<Image> &p_image, const Color &p_color, bool p_scale, bool p_use_filter = true);
 	virtual void set_shader_time_scale(float p_scale);

--- a/drivers/gles3/rasterizer_scene_gles3.cpp
+++ b/drivers/gles3/rasterizer_scene_gles3.cpp
@@ -1144,7 +1144,7 @@ bool RasterizerSceneGLES3::_setup_material(RasterizerStorageGLES3::Material *p_m
 
 	//material parameters
 
-	state.scene_shader.set_custom_shader(p_material->shader->custom_code_id);
+	state.scene_shader.set_custom_shader(p_material->shader->custom_code_id, p_material->path);
 	bool rebind = state.scene_shader.bind();
 	if (!ShaderGLES3::get_active()) {
 		return false;

--- a/drivers/gles3/rasterizer_storage_gles3.cpp
+++ b/drivers/gles3/rasterizer_storage_gles3.cpp
@@ -2602,6 +2602,32 @@ RID RasterizerStorageGLES3::material_get_shader(RID p_material) const {
 	return RID();
 }
 
+Dictionary RasterizerStorageGLES3::material_precompile_shader_variant(RID p_material, const PoolStringArray &p_enabled_conditionals) {
+	Dictionary result;
+	result["success"] = false;
+
+	Material *material = material_owner.getornull(p_material);
+	if (!material) {
+		result["error"] = "invalid_material";
+		return result;
+	}
+	if (!material->shader) {
+		result["error"] = "material_has_no_shader";
+		return result;
+	}
+
+	Shader *shader = material->shader;
+	if (shader->dirty_list.in_list()) {
+		_update_shader(shader);
+	}
+	if (!shader->valid || !shader->shader || shader->custom_code_id == 0) {
+		result["error"] = "invalid_shader";
+		return result;
+	}
+
+	return shader->shader->precompile_custom_shader_variant(shader->custom_code_id, p_enabled_conditionals, material->path);
+}
+
 void RasterizerStorageGLES3::material_set_param(RID p_material, const StringName &p_param, const Variant &p_value) {
 	Material *material = material_owner.get(p_material);
 	ERR_FAIL_COND(!material);

--- a/drivers/gles3/rasterizer_storage_gles3.cpp
+++ b/drivers/gles3/rasterizer_storage_gles3.cpp
@@ -2566,6 +2566,12 @@ RID RasterizerStorageGLES3::material_create() {
 	return material_owner.make_rid(material);
 }
 
+void RasterizerStorageGLES3::material_set_path(RID p_material, const String &p_path) {
+	Material *material = material_owner.get(p_material);
+	ERR_FAIL_COND(!material);
+	material->path = p_path;
+}
+
 void RasterizerStorageGLES3::material_set_shader(RID p_material, RID p_shader) {
 	Material *material = material_owner.get(p_material);
 	ERR_FAIL_COND(!material);
@@ -6663,7 +6669,7 @@ void RasterizerStorageGLES3::update_particles() {
 		if (!material || !material->shader || material->shader->mode != VS::SHADER_PARTICLES) {
 			shaders.particles.set_custom_shader(0);
 		} else {
-			shaders.particles.set_custom_shader(material->shader->custom_code_id);
+			shaders.particles.set_custom_shader(material->shader->custom_code_id, material->path);
 
 			if (material->ubo_id) {
 				glBindBufferBase(GL_UNIFORM_BUFFER, 0, material->ubo_id);

--- a/drivers/gles3/rasterizer_storage_gles3.h
+++ b/drivers/gles3/rasterizer_storage_gles3.h
@@ -575,6 +575,7 @@ public:
 
 	struct Material : public RID_Data {
 		Shader *shader;
+		String path;
 		GLuint ubo_id;
 		uint32_t ubo_size;
 		Map<StringName, Variant> params;
@@ -619,6 +620,7 @@ public:
 
 	virtual RID material_create();
 
+	virtual void material_set_path(RID p_material, const String &p_path);
 	virtual void material_set_shader(RID p_material, RID p_shader);
 	virtual RID material_get_shader(RID p_material) const;
 

--- a/drivers/gles3/rasterizer_storage_gles3.h
+++ b/drivers/gles3/rasterizer_storage_gles3.h
@@ -623,6 +623,7 @@ public:
 	virtual void material_set_path(RID p_material, const String &p_path);
 	virtual void material_set_shader(RID p_material, RID p_shader);
 	virtual RID material_get_shader(RID p_material) const;
+	virtual Dictionary material_precompile_shader_variant(RID p_material, const PoolStringArray &p_enabled_conditionals);
 
 	virtual void material_set_param(RID p_material, const StringName &p_param, const Variant &p_value);
 	virtual Variant material_get_param(RID p_material, const StringName &p_param) const;

--- a/drivers/gles3/shader_gles3.cpp
+++ b/drivers/gles3/shader_gles3.cpp
@@ -1550,7 +1550,7 @@ Dictionary ShaderGLES3::precompile_custom_shader_variant(uint32_t p_code_id, con
 	result["material_path"] = p_material_path;
 
 	CustomCode *custom_code = custom_code_map.getptr(p_code_id);
-	if (!custom_code) {
+	if (p_code_id != CUSTOM_SHADER_DISABLED && !custom_code) {
 		result["error"] = "invalid_custom_code_id";
 		return result;
 	}
@@ -1586,13 +1586,14 @@ Dictionary ShaderGLES3::precompile_custom_shader_variant(uint32_t p_code_id, con
 	result["enabled_conditionals"] = normalized_conditionals;
 	result["variant"] = requested_variant;
 	result["custom_code_id"] = p_code_id;
-	result["custom_code_version"] = custom_code->version;
+	result["custom_code_version"] = custom_code ? custom_code->version : 0;
 
 	VersionKey requested_key;
 	requested_key.version = requested_variant;
 	requested_key.code_version = p_code_id;
 	const Version *existing = version_map.getptr(requested_key);
-	const bool already_compiled = existing && existing->code_version == custom_code->version && existing->compile_status == Version::COMPILE_STATUS_OK;
+	const uint32_t requested_code_version = custom_code ? custom_code->version : 0;
+	const bool already_compiled = existing && existing->code_version == requested_code_version && existing->compile_status == Version::COMPILE_STATUS_OK;
 
 	const VersionKey previous_requested_version = new_conditional_version;
 	const String previous_material_path = diagnostic_material_path;

--- a/drivers/gles3/shader_gles3.cpp
+++ b/drivers/gles3/shader_gles3.cpp
@@ -1269,17 +1269,28 @@ bool ShaderGLES3::_reuse_resident_program(Version *p_version) {
 	if (!Engine::get_singleton()->is_shader_program_residency_enabled()) {
 		return false;
 	}
-	const ResidentProgram *resident = resident_programs.getptr(p_version->resident_program_key);
+	ResidentProgram *resident = resident_programs.getptr(p_version->resident_program_key);
 	if (!resident) {
 		return false;
 	}
 
+	_claim_resident_program(resident);
 	p_version->ids = resident->ids;
 	p_version->program_binary.source = Version::ProgramBinary::SOURCE_NONE;
 	p_version->compile_status = Version::COMPILE_STATUS_OK;
 	p_version->uniforms_ready = false;
 	p_version->diagnostic_resident_program_hit = true;
 	return true;
+}
+
+void ShaderGLES3::_claim_resident_program(ResidentProgram *p_resident) {
+	ERR_FAIL_NULL(p_resident);
+	const String owner = Engine::get_singleton()->get_shader_program_residency_owner();
+	if (owner.empty()) {
+		return;
+	}
+	p_resident->owner_managed = true;
+	p_resident->owners.insert(owner);
 }
 
 void ShaderGLES3::_retain_resident_program(Version *p_version) {
@@ -1290,6 +1301,7 @@ void ShaderGLES3::_retain_resident_program(Version *p_version) {
 
 	ResidentProgram *resident = resident_programs.getptr(p_version->resident_program_key);
 	if (resident) {
+		_claim_resident_program(resident);
 		if (resident->ids.main != p_version->ids.main) {
 			glDeleteShader(p_version->ids.vert);
 			glDeleteShader(p_version->ids.frag);
@@ -1301,8 +1313,85 @@ void ShaderGLES3::_retain_resident_program(Version *p_version) {
 
 	ResidentProgram stored;
 	stored.ids = p_version->ids;
+	_claim_resident_program(&stored);
 	resident_programs[p_version->resident_program_key] = stored;
 	Engine::get_singleton()->notify_shader_program_retained();
+}
+
+uint32_t ShaderGLES3::_evict_resident_program(const String &p_program_key) {
+	ResidentProgram *resident = resident_programs.getptr(p_program_key);
+	ERR_FAIL_NULL_V(resident, 0);
+
+	if (version && version->resident_program_key == p_program_key) {
+		if (active == this) {
+			unbind();
+		} else {
+			version = nullptr;
+		}
+	}
+
+	Vector<VersionKey> versions_to_remove;
+	const VersionKey *version_key = nullptr;
+	while ((version_key = version_map.next(version_key))) {
+		const Version &candidate = version_map[*version_key];
+		if (candidate.resident_program_key == p_program_key) {
+			versions_to_remove.push_back(*version_key);
+		}
+	}
+
+	for (int i = 0; i < versions_to_remove.size(); i++) {
+		const VersionKey key = versions_to_remove[i];
+		Version &candidate = version_map[key];
+		if (key.code_version != CUSTOM_SHADER_DISABLED) {
+			CustomCode *custom_code = custom_code_map.getptr(key.code_version);
+			if (custom_code) {
+				custom_code->versions.erase(key.version);
+			}
+		}
+		_dispose_program(&candidate);
+		memdelete_arr(candidate.uniform_location);
+		version_map.erase(key);
+	}
+
+	glDeleteShader(resident->ids.vert);
+	glDeleteShader(resident->ids.frag);
+	glDeleteProgram(resident->ids.main);
+	resident_programs.erase(p_program_key);
+	Engine::get_singleton()->notify_shader_program_released();
+	return versions_to_remove.size();
+}
+
+Dictionary ShaderGLES3::release_resident_program_owner(const String &p_owner) {
+	Dictionary result;
+	result["programs_released"] = 0;
+	result["versions_invalidated"] = 0;
+	if (p_owner.empty()) {
+		result["success"] = false;
+		result["error"] = "empty_owner";
+		return result;
+	}
+
+	Vector<String> programs_to_release;
+	const String *program_key = nullptr;
+	while ((program_key = resident_programs.next(program_key))) {
+		ResidentProgram &resident = resident_programs[*program_key];
+		if (!resident.owner_managed || !resident.owners.has(p_owner)) {
+			continue;
+		}
+		resident.owners.erase(p_owner);
+		if (resident.owners.empty()) {
+			programs_to_release.push_back(*program_key);
+		}
+	}
+
+	uint32_t versions_invalidated = 0;
+	for (int i = 0; i < programs_to_release.size(); i++) {
+		versions_invalidated += _evict_resident_program(programs_to_release[i]);
+	}
+	result["success"] = true;
+	result["programs_released"] = programs_to_release.size();
+	result["versions_invalidated"] = versions_invalidated;
+	return result;
 }
 
 void ShaderGLES3::_free_resident_programs() {
@@ -1606,6 +1695,12 @@ Dictionary ShaderGLES3::precompile_custom_shader_variant(uint32_t p_code_id, con
 
 	Version *compiled_version = version;
 	const bool success = bound && compiled_version && compiled_version->compile_status == Version::COMPILE_STATUS_OK;
+	if (success) {
+		ResidentProgram *resident = resident_programs.getptr(compiled_version->resident_program_key);
+		if (resident) {
+			_claim_resident_program(resident);
+		}
+	}
 	result["success"] = success;
 	result["already_compiled"] = already_compiled;
 	result["resident_program_count"] = Engine::get_singleton()->get_shader_resident_program_count();

--- a/drivers/gles3/shader_gles3.cpp
+++ b/drivers/gles3/shader_gles3.cpp
@@ -296,7 +296,7 @@ void ShaderGLES3::_diagnostic_start(Version *p_version, const String &p_operatio
 	event.cache_lookup_attempted = p_version->diagnostic_cache_lookup_attempted;
 	event.cache_hit = p_version->diagnostic_cache_hit;
 	event.resident_program_hit = p_version->diagnostic_resident_program_hit;
-	event.program_cache_key = p_version->diagnostic_program_cache_key;
+	event.program_cache_key = p_version->resident_program_key;
 	event.vertex_source_hash = p_version->diagnostic_vertex_source_hash;
 	event.fragment_source_hash = p_version->diagnostic_fragment_source_hash;
 	event.enabled_conditionals = p_version->diagnostic_enabled_conditionals;
@@ -342,7 +342,7 @@ void ShaderGLES3::_diagnostic_finish(Version *p_version, bool p_success) {
 	event.cache_lookup_attempted = p_version->diagnostic_cache_lookup_attempted;
 	event.cache_hit = p_version->diagnostic_cache_hit;
 	event.resident_program_hit = p_version->diagnostic_resident_program_hit;
-	event.program_cache_key = p_version->diagnostic_program_cache_key;
+	event.program_cache_key = p_version->resident_program_key;
 	event.vertex_source_hash = p_version->diagnostic_vertex_source_hash;
 	event.fragment_source_hash = p_version->diagnostic_fragment_source_hash;
 	event.enabled_conditionals = p_version->diagnostic_enabled_conditionals;
@@ -742,9 +742,7 @@ ShaderGLES3::Version *ShaderGLES3::get_current_version(bool &r_async_forbidden) 
 	bool build_ubershader = get_ubershader_flags_uniform() != -1 && (effective_version.version & VersionKey::UBERSHADER_FLAG);
 	if (build_ubershader) {
 		strings_common.push_back("#define IS_UBERSHADER\n");
-		if (v.diagnostic_debug_target) {
-			v.diagnostic_enabled_conditionals.push_back("IS_UBERSHADER");
-		}
+		v.diagnostic_enabled_conditionals.push_back("IS_UBERSHADER");
 		for (int i = 0; i < conditional_count; i++) {
 			String s = vformat("#define FLAG_%s (1 << %d)\n", String(conditional_defines[i]).strip_edges().trim_prefix("#define "), i);
 			CharString cs = s.ascii();
@@ -756,7 +754,7 @@ ShaderGLES3::Version *ShaderGLES3::get_current_version(bool &r_async_forbidden) 
 		for (int i = 0; i < conditional_count; i++) {
 			bool enable = ((1 << i) & effective_version.version);
 			strings_common.push_back(enable ? conditional_defines[i] : "");
-			if (enable && v.diagnostic_debug_target) {
+			if (enable) {
 				v.diagnostic_enabled_conditionals.push_back(String(conditional_defines[i]).strip_edges().trim_prefix("#define ").strip_edges());
 			}
 

--- a/drivers/gles3/shader_gles3.cpp
+++ b/drivers/gles3/shader_gles3.cpp
@@ -258,6 +258,14 @@ String ShaderGLES3::_diagnostic_source(const Version *p_version) const {
 	return "unknown";
 }
 
+String ShaderGLES3::_join_shader_source(const LocalVector<const char *> &p_strings) {
+	String source;
+	for (uint32_t i = 0; i < p_strings.size(); i++) {
+		source += String::utf8(p_strings[i]);
+	}
+	return source;
+}
+
 void ShaderGLES3::_diagnostic_start(Version *p_version, const String &p_operation) {
 	Engine *engine = Engine::get_singleton();
 	if (p_version->diagnostic_started || !engine->is_shader_compilation_tracking_enabled()) {
@@ -271,6 +279,7 @@ void ShaderGLES3::_diagnostic_start(Version *p_version, const String &p_operatio
 	event.render_frame = current_frame;
 	event.variant = p_version->version_key.version;
 	event.custom_code_id = p_version->version_key.code_version;
+	event.custom_code_version = p_version->diagnostic_custom_code_version;
 	event.phase = "started";
 	event.operation = p_operation;
 	event.backend = "gles3";
@@ -278,9 +287,22 @@ void ShaderGLES3::_diagnostic_start(Version *p_version, const String &p_operatio
 	event.source = _diagnostic_source(p_version);
 	event.shader_name = get_shader_name();
 	event.material_path = p_version->diagnostic_material_path;
+	event.debug_target = p_version->diagnostic_debug_target;
+	event.cache_eligible = p_version->diagnostic_cache_eligible;
+	event.cache_lookup_attempted = p_version->diagnostic_cache_lookup_attempted;
+	event.cache_hit = p_version->diagnostic_cache_hit;
+	event.program_cache_key = p_version->diagnostic_program_cache_key;
+	event.vertex_source_hash = p_version->diagnostic_vertex_source_hash;
+	event.fragment_source_hash = p_version->diagnostic_fragment_source_hash;
+	event.enabled_conditionals = p_version->diagnostic_enabled_conditionals;
+	event.custom_defines = p_version->diagnostic_custom_defines;
+	event.generated_vertex_source = p_version->diagnostic_vertex_source;
+	event.generated_fragment_source = p_version->diagnostic_fragment_source;
 	event.success = true;
 	p_version->diagnostic_compilation_id = engine->record_shader_compilation_event(event);
 	p_version->diagnostic_started = p_version->diagnostic_compilation_id != 0;
+	p_version->diagnostic_vertex_source = String();
+	p_version->diagnostic_fragment_source = String();
 }
 
 void ShaderGLES3::_diagnostic_finish(Version *p_version, bool p_success) {
@@ -302,6 +324,7 @@ void ShaderGLES3::_diagnostic_finish(Version *p_version, bool p_success) {
 	event.render_frame = current_frame;
 	event.variant = p_version->version_key.version;
 	event.custom_code_id = p_version->version_key.code_version;
+	event.custom_code_version = p_version->diagnostic_custom_code_version;
 	event.phase = "finished";
 	event.operation = p_version->program_binary.source == Version::ProgramBinary::SOURCE_CACHE ? "program_binary_load" : "compile";
 	event.backend = "gles3";
@@ -309,6 +332,15 @@ void ShaderGLES3::_diagnostic_finish(Version *p_version, bool p_success) {
 	event.source = _diagnostic_source(p_version);
 	event.shader_name = get_shader_name();
 	event.material_path = p_version->diagnostic_material_path;
+	event.debug_target = p_version->diagnostic_debug_target;
+	event.cache_eligible = p_version->diagnostic_cache_eligible;
+	event.cache_lookup_attempted = p_version->diagnostic_cache_lookup_attempted;
+	event.cache_hit = p_version->diagnostic_cache_hit;
+	event.program_cache_key = p_version->diagnostic_program_cache_key;
+	event.vertex_source_hash = p_version->diagnostic_vertex_source_hash;
+	event.fragment_source_hash = p_version->diagnostic_fragment_source_hash;
+	event.enabled_conditionals = p_version->diagnostic_enabled_conditionals;
+	event.custom_defines = p_version->diagnostic_custom_defines;
 	event.success = p_success;
 	engine->record_shader_compilation_event(event);
 }
@@ -654,6 +686,18 @@ ShaderGLES3::Version *ShaderGLES3::get_current_version(bool &r_async_forbidden) 
 	v.diagnostic_compilation_id = 0;
 	v.diagnostic_started_usec = 0;
 	v.diagnostic_material_path = diagnostic_material_path;
+	v.diagnostic_custom_code_version = 0;
+	v.diagnostic_program_cache_key = String();
+	v.diagnostic_vertex_source_hash = String();
+	v.diagnostic_fragment_source_hash = String();
+	v.diagnostic_vertex_source = String();
+	v.diagnostic_fragment_source = String();
+	v.diagnostic_enabled_conditionals.clear();
+	v.diagnostic_custom_defines.clear();
+	v.diagnostic_debug_target = Engine::get_singleton()->is_shader_compilation_debug_target(diagnostic_material_path);
+	v.diagnostic_cache_eligible = effective_version.is_subject_to_caching();
+	v.diagnostic_cache_lookup_attempted = false;
+	v.diagnostic_cache_hit = false;
 	v.diagnostic_started = false;
 	v.diagnostic_finished = false;
 
@@ -674,6 +718,9 @@ ShaderGLES3::Version *ShaderGLES3::get_current_version(bool &r_async_forbidden) 
 	for (int i = 0; i < custom_defines.size(); i++) {
 		strings_common.push_back(custom_defines[i].get_data());
 		strings_common.push_back("\n");
+		if (v.diagnostic_debug_target) {
+			v.diagnostic_custom_defines.push_back(String(custom_defines[i]).strip_edges());
+		}
 	}
 
 	if (is_async_compilation_supported() && get_ubershader_flags_uniform() != -1) {
@@ -685,6 +732,9 @@ ShaderGLES3::Version *ShaderGLES3::get_current_version(bool &r_async_forbidden) 
 	bool build_ubershader = get_ubershader_flags_uniform() != -1 && (effective_version.version & VersionKey::UBERSHADER_FLAG);
 	if (build_ubershader) {
 		strings_common.push_back("#define IS_UBERSHADER\n");
+		if (v.diagnostic_debug_target) {
+			v.diagnostic_enabled_conditionals.push_back("IS_UBERSHADER");
+		}
 		for (int i = 0; i < conditional_count; i++) {
 			String s = vformat("#define FLAG_%s (1 << %d)\n", String(conditional_defines[i]).strip_edges().trim_prefix("#define "), i);
 			CharString cs = s.ascii();
@@ -696,6 +746,9 @@ ShaderGLES3::Version *ShaderGLES3::get_current_version(bool &r_async_forbidden) 
 		for (int i = 0; i < conditional_count; i++) {
 			bool enable = ((1 << i) & effective_version.version);
 			strings_common.push_back(enable ? conditional_defines[i] : "");
+			if (enable && v.diagnostic_debug_target) {
+				v.diagnostic_enabled_conditionals.push_back(String(conditional_defines[i]).strip_edges().trim_prefix("#define ").strip_edges());
+			}
 
 			if (enable) {
 				DEBUG_PRINT(conditional_defines[i]);
@@ -727,6 +780,7 @@ ShaderGLES3::Version *ShaderGLES3::get_current_version(bool &r_async_forbidden) 
 			v.uniforms_ready = false;
 		}
 	}
+	v.diagnostic_custom_code_version = v.code_version;
 
 	/* CREATE PROGRAM */
 
@@ -743,6 +797,9 @@ ShaderGLES3::Version *ShaderGLES3::get_current_version(bool &r_async_forbidden) 
 	if (cc) {
 		for (int i = 0; i < cc->custom_defines.size(); i++) {
 			strings_common.push_back(cc->custom_defines[i].get_data());
+			if (v.diagnostic_debug_target) {
+				v.diagnostic_custom_defines.push_back(String(cc->custom_defines[i]).strip_edges());
+			}
 			DEBUG_PRINT("CD #" + itos(i) + ": " + String(cc->custom_defines[i]));
 		}
 	}
@@ -899,17 +956,31 @@ ShaderGLES3::Version *ShaderGLES3::get_current_version(bool &r_async_forbidden) 
 				(v.async_mode == ASYNC_MODE_VISIBLE && get_ubershader_flags_uniform() == -1);
 	}
 
-	bool in_cache = false;
-	if (shader_cache && effective_version.is_subject_to_caching()) {
-		const char *strings_platform[] = {
-			reinterpret_cast<const char *>(glGetString(GL_VENDOR)),
-			reinterpret_cast<const char *>(glGetString(GL_RENDERER)),
-			reinterpret_cast<const char *>(glGetString(GL_VERSION)),
-			nullptr,
-		};
+	const char *strings_platform[] = {
+		reinterpret_cast<const char *>(glGetString(GL_VENDOR)),
+		reinterpret_cast<const char *>(glGetString(GL_RENDERER)),
+		reinterpret_cast<const char *>(glGetString(GL_VERSION)),
+		nullptr,
+	};
+	if (v.diagnostic_cache_eligible || v.diagnostic_debug_target) {
 		v.program_binary.cache_hash = ShaderCacheGLES3::hash_program(strings_platform, strings_vertex, strings_fragment);
+		v.diagnostic_program_cache_key = v.program_binary.cache_hash;
+	}
+	if (v.diagnostic_debug_target) {
+		const char *no_platform_strings[] = { nullptr };
+		LocalVector<const char *> no_shader_strings;
+		v.diagnostic_vertex_source_hash = ShaderCacheGLES3::hash_program(no_platform_strings, strings_vertex, no_shader_strings);
+		v.diagnostic_fragment_source_hash = ShaderCacheGLES3::hash_program(no_platform_strings, no_shader_strings, strings_fragment);
+		v.diagnostic_vertex_source = _join_shader_source(strings_vertex);
+		v.diagnostic_fragment_source = _join_shader_source(strings_fragment);
+	}
+
+	bool in_cache = false;
+	if (shader_cache && v.diagnostic_cache_eligible) {
+		v.diagnostic_cache_lookup_attempted = true;
 		if (shader_cache->retrieve(v.program_binary.cache_hash, &v.program_binary.format, &v.program_binary.data)) {
 			in_cache = true;
+			v.diagnostic_cache_hit = true;
 			v.program_binary.source = Version::ProgramBinary::SOURCE_CACHE;
 			v.compile_status = Version::COMPILE_STATUS_BINARY_READY_FROM_CACHE;
 		}

--- a/drivers/gles3/shader_gles3.cpp
+++ b/drivers/gles3/shader_gles3.cpp
@@ -30,6 +30,7 @@
 
 #include "shader_gles3.h"
 
+#include "core/engine.h"
 #include "core/local_vector.h"
 #include "core/os/os.h"
 #include "core/print_string.h"
@@ -233,6 +234,85 @@ void ShaderGLES3::_log_active_compiles() {
 #endif
 }
 
+String ShaderGLES3::_diagnostic_compilation_mode() const {
+	if (compile_queue) {
+		return "secondary_context_queue";
+	}
+	if (parallel_compile_supported) {
+		return "parallel_compile";
+	}
+	return "synchronous";
+}
+
+String ShaderGLES3::_diagnostic_source(const Version *p_version) const {
+	switch (p_version->program_binary.source) {
+		case Version::ProgramBinary::SOURCE_LOCAL:
+			return "source";
+		case Version::ProgramBinary::SOURCE_QUEUE:
+			return "compile_queue";
+		case Version::ProgramBinary::SOURCE_CACHE:
+			return "program_binary_cache";
+		case Version::ProgramBinary::SOURCE_NONE:
+			return "unknown";
+	}
+	return "unknown";
+}
+
+void ShaderGLES3::_diagnostic_start(Version *p_version, const String &p_operation) {
+	Engine *engine = Engine::get_singleton();
+	if (p_version->diagnostic_started || !engine->is_shader_compilation_tracking_enabled()) {
+		return;
+	}
+
+	p_version->diagnostic_started_usec = OS::get_singleton()->get_ticks_usec();
+	Engine::ShaderCompilationEvent event;
+	event.timestamp_usec = p_version->diagnostic_started_usec;
+	event.idle_frame = engine->get_idle_frames();
+	event.render_frame = current_frame;
+	event.variant = p_version->version_key.version;
+	event.custom_code_id = p_version->version_key.code_version;
+	event.phase = "started";
+	event.operation = p_operation;
+	event.backend = "gles3";
+	event.compilation_mode = _diagnostic_compilation_mode();
+	event.source = _diagnostic_source(p_version);
+	event.shader_name = get_shader_name();
+	event.material_path = p_version->diagnostic_material_path;
+	event.success = true;
+	p_version->diagnostic_compilation_id = engine->record_shader_compilation_event(event);
+	p_version->diagnostic_started = p_version->diagnostic_compilation_id != 0;
+}
+
+void ShaderGLES3::_diagnostic_finish(Version *p_version, bool p_success) {
+	if (!p_version->diagnostic_started || p_version->diagnostic_finished) {
+		return;
+	}
+	p_version->diagnostic_finished = true;
+
+	Engine *engine = Engine::get_singleton();
+	if (!engine->is_shader_compilation_tracking_enabled()) {
+		return;
+	}
+
+	Engine::ShaderCompilationEvent event;
+	event.compilation_id = p_version->diagnostic_compilation_id;
+	event.timestamp_usec = OS::get_singleton()->get_ticks_usec();
+	event.duration_usec = event.timestamp_usec - p_version->diagnostic_started_usec;
+	event.idle_frame = engine->get_idle_frames();
+	event.render_frame = current_frame;
+	event.variant = p_version->version_key.version;
+	event.custom_code_id = p_version->version_key.code_version;
+	event.phase = "finished";
+	event.operation = p_version->program_binary.source == Version::ProgramBinary::SOURCE_CACHE ? "program_binary_load" : "compile";
+	event.backend = "gles3";
+	event.compilation_mode = _diagnostic_compilation_mode();
+	event.source = _diagnostic_source(p_version);
+	event.shader_name = get_shader_name();
+	event.material_path = p_version->diagnostic_material_path;
+	event.success = p_success;
+	engine->record_shader_compilation_event(event);
+}
+
 bool ShaderGLES3::_process_program_state(Version *p_version, bool p_async_forbidden) {
 	bool ready = false;
 	bool run_next_step = true;
@@ -251,6 +331,7 @@ bool ShaderGLES3::_process_program_state(Version *p_version, bool p_async_forbid
 				// These lead to nowhere unless other piece of code starts the compile process
 			} break;
 			case Version::COMPILE_STATUS_SOURCE_PROVIDED: {
+				p_version->shader->_diagnostic_start(p_version, "compile");
 				uint32_t start_compiles_count = p_async_forbidden ? 2 : 0;
 				if (!start_compiles_count) {
 					uint32_t used_async_slots = MAX(active_compiles_count, *compiles_started_this_frame);
@@ -337,6 +418,7 @@ bool ShaderGLES3::_process_program_state(Version *p_version, bool p_async_forbid
 						run_next_step = p_async_forbidden;
 					} else {
 						p_version->compile_status = Version::COMPILE_STATUS_ERROR;
+						p_version->shader->_diagnostic_finish(p_version, false);
 						if (p_version->compiling_list.in_list()) {
 							p_version->compiling_list.remove_from_list();
 							active_compiles_count--;
@@ -353,6 +435,7 @@ bool ShaderGLES3::_process_program_state(Version *p_version, bool p_async_forbid
 				switch (p_version->program_binary.result_from_queue.get()) {
 					case -1: { // Error
 						p_version->compile_status = Version::COMPILE_STATUS_ERROR;
+						p_version->shader->_diagnostic_finish(p_version, false);
 						p_version->compiling_list.remove_from_list();
 						active_compiles_count--;
 #ifdef DEV_ENABLED
@@ -392,6 +475,9 @@ bool ShaderGLES3::_process_program_state(Version *p_version, bool p_async_forbid
 				}
 			} break;
 			case Version::COMPILE_STATUS_BINARY_READY: {
+				if (p_version->program_binary.source == Version::ProgramBinary::SOURCE_CACHE) {
+					p_version->shader->_diagnostic_start(p_version, "program_binary_load");
+				}
 				PoolByteArray::Read r = p_version->program_binary.data.read();
 				glProgramBinary(p_version->ids.main, static_cast<GLenum>(p_version->program_binary.format), r.ptr(), p_version->program_binary.data.size());
 				p_version->compile_status = Version::COMPILE_STATUS_LINKING;
@@ -430,8 +516,10 @@ bool ShaderGLES3::_process_program_state(Version *p_version, bool p_async_forbid
 							});
 						}
 						p_version->compile_status = Version::COMPILE_STATUS_OK;
+						p_version->shader->_diagnostic_finish(p_version, true);
 						ready = true;
 					} else {
+						p_version->shader->_diagnostic_finish(p_version, false);
 						if (p_version->program_binary.source == Version::ProgramBinary::SOURCE_CACHE) {
 #ifdef DEBUG_ENABLED
 							WARN_PRINT("Program binary from cache has been rejected by the GL. Removing from cache.");
@@ -563,6 +651,11 @@ ShaderGLES3::Version *ShaderGLES3::get_current_version(bool &r_async_forbidden) 
 	}
 
 	Version &v = *_v;
+	v.diagnostic_compilation_id = 0;
+	v.diagnostic_started_usec = 0;
+	v.diagnostic_material_path = diagnostic_material_path;
+	v.diagnostic_started = false;
+	v.diagnostic_finished = false;
 
 	/* SETUP CONDITIONALS */
 
@@ -849,6 +942,7 @@ ShaderGLES3::Version *ShaderGLES3::get_current_version(bool &r_async_forbidden) 
 
 			v.program_binary.source = Version::ProgramBinary::SOURCE_QUEUE;
 			v.compile_status = Version::COMPILE_STATUS_PROCESSING_AT_QUEUE;
+			_diagnostic_start(&v, "compile");
 			versions_compiling.add_last(&v.compiling_list);
 			active_compiles_count++;
 			*max_frame_compiles_in_progress = MAX(*max_frame_compiles_in_progress, active_compiles_count);
@@ -1087,6 +1181,7 @@ void ShaderGLES3::_setup_uniforms(CustomCode *p_cc) const {
 }
 
 void ShaderGLES3::_dispose_program(Version *p_version) {
+	_diagnostic_finish(p_version, false);
 	if (compile_queue) {
 		if (p_version->compile_status == Version::COMPILE_STATUS_PROCESSING_AT_QUEUE) {
 			compile_queue->cancel(p_version->ids.main);
@@ -1284,13 +1379,15 @@ void ShaderGLES3::set_custom_shader_code(uint32_t p_code_id, const String &p_ver
 
 	if (p_async_mode == ASYNC_MODE_VISIBLE && is_async_compilation_supported() && get_ubershader_flags_uniform() != -1) {
 		// Warm up the ubershader for this custom code
+		diagnostic_material_path = String();
 		new_conditional_version.code_version = p_code_id;
 		_bind_ubershader(true);
 	}
 }
 
-void ShaderGLES3::set_custom_shader(uint32_t p_code_id) {
+void ShaderGLES3::set_custom_shader(uint32_t p_code_id, const String &p_material_path) {
 	new_conditional_version.code_version = p_code_id;
+	diagnostic_material_path = p_material_path;
 }
 
 void ShaderGLES3::free_custom_shader(uint32_t p_code_id) {

--- a/drivers/gles3/shader_gles3.cpp
+++ b/drivers/gles3/shader_gles3.cpp
@@ -703,7 +703,8 @@ ShaderGLES3::Version *ShaderGLES3::get_current_version(bool &r_async_forbidden) 
 	v.diagnostic_custom_defines.clear();
 	v.diagnostic_operation = String();
 	v.resident_program_key = String();
-	v.diagnostic_debug_target = Engine::get_singleton()->is_shader_compilation_debug_target(diagnostic_material_path);
+	const bool tracking_enabled = Engine::get_singleton()->is_shader_compilation_tracking_enabled();
+	v.diagnostic_debug_target = tracking_enabled && Engine::get_singleton()->is_shader_compilation_debug_target(diagnostic_material_path);
 	v.diagnostic_cache_eligible = effective_version.is_subject_to_caching();
 	v.diagnostic_cache_lookup_attempted = false;
 	v.diagnostic_cache_hit = false;
@@ -742,7 +743,9 @@ ShaderGLES3::Version *ShaderGLES3::get_current_version(bool &r_async_forbidden) 
 	bool build_ubershader = get_ubershader_flags_uniform() != -1 && (effective_version.version & VersionKey::UBERSHADER_FLAG);
 	if (build_ubershader) {
 		strings_common.push_back("#define IS_UBERSHADER\n");
-		v.diagnostic_enabled_conditionals.push_back("IS_UBERSHADER");
+		if (tracking_enabled) {
+			v.diagnostic_enabled_conditionals.push_back("IS_UBERSHADER");
+		}
 		for (int i = 0; i < conditional_count; i++) {
 			String s = vformat("#define FLAG_%s (1 << %d)\n", String(conditional_defines[i]).strip_edges().trim_prefix("#define "), i);
 			CharString cs = s.ascii();
@@ -754,7 +757,7 @@ ShaderGLES3::Version *ShaderGLES3::get_current_version(bool &r_async_forbidden) 
 		for (int i = 0; i < conditional_count; i++) {
 			bool enable = ((1 << i) & effective_version.version);
 			strings_common.push_back(enable ? conditional_defines[i] : "");
-			if (enable) {
+			if (tracking_enabled && enable) {
 				v.diagnostic_enabled_conditionals.push_back(String(conditional_defines[i]).strip_edges().trim_prefix("#define ").strip_edges());
 			}
 
@@ -1307,6 +1310,7 @@ void ShaderGLES3::_retain_resident_program(Version *p_version) {
 			glDeleteShader(p_version->ids.frag);
 			glDeleteProgram(p_version->ids.main);
 			p_version->ids = resident->ids;
+			p_version->uniforms_ready = false;
 		}
 		return;
 	}
@@ -1322,7 +1326,7 @@ uint32_t ShaderGLES3::_evict_resident_program(const String &p_program_key) {
 	ResidentProgram *resident = resident_programs.getptr(p_program_key);
 	ERR_FAIL_NULL_V(resident, 0);
 
-	if (version && version->resident_program_key == p_program_key) {
+	if (version && version->resident_program_key == p_program_key && version->ids.main == resident->ids.main) {
 		if (active == this) {
 			unbind();
 		} else {
@@ -1334,7 +1338,8 @@ uint32_t ShaderGLES3::_evict_resident_program(const String &p_program_key) {
 	const VersionKey *version_key = nullptr;
 	while ((version_key = version_map.next(version_key))) {
 		const Version &candidate = version_map[*version_key];
-		if (candidate.resident_program_key == p_program_key) {
+		// Matching sources can still have a separate program compiling on the worker.
+		if (candidate.resident_program_key == p_program_key && candidate.ids.main == resident->ids.main) {
 			versions_to_remove.push_back(*version_key);
 		}
 	}
@@ -1696,10 +1701,7 @@ Dictionary ShaderGLES3::precompile_custom_shader_variant(uint32_t p_code_id, con
 	Version *compiled_version = version;
 	const bool success = bound && compiled_version && compiled_version->compile_status == Version::COMPILE_STATUS_OK;
 	if (success) {
-		ResidentProgram *resident = resident_programs.getptr(compiled_version->resident_program_key);
-		if (resident) {
-			_claim_resident_program(resident);
-		}
+		_retain_resident_program(compiled_version);
 	}
 	result["success"] = success;
 	result["already_compiled"] = already_compiled;

--- a/drivers/gles3/shader_gles3.cpp
+++ b/drivers/gles3/shader_gles3.cpp
@@ -1266,6 +1266,9 @@ void ShaderGLES3::_setup_uniforms(CustomCode *p_cc) const {
 }
 
 bool ShaderGLES3::_reuse_resident_program(Version *p_version) {
+	if (!Engine::get_singleton()->is_shader_program_residency_enabled()) {
+		return false;
+	}
 	const ResidentProgram *resident = resident_programs.getptr(p_version->resident_program_key);
 	if (!resident) {
 		return false;
@@ -1280,6 +1283,9 @@ bool ShaderGLES3::_reuse_resident_program(Version *p_version) {
 }
 
 void ShaderGLES3::_retain_resident_program(Version *p_version) {
+	if (!Engine::get_singleton()->is_shader_program_residency_enabled()) {
+		return;
+	}
 	ERR_FAIL_COND(p_version->resident_program_key.empty());
 
 	ResidentProgram *resident = resident_programs.getptr(p_version->resident_program_key);
@@ -1296,6 +1302,7 @@ void ShaderGLES3::_retain_resident_program(Version *p_version) {
 	ResidentProgram stored;
 	stored.ids = p_version->ids;
 	resident_programs[p_version->resident_program_key] = stored;
+	Engine::get_singleton()->notify_shader_program_retained();
 }
 
 void ShaderGLES3::_free_resident_programs() {
@@ -1305,6 +1312,7 @@ void ShaderGLES3::_free_resident_programs() {
 		glDeleteShader(resident.ids.vert);
 		glDeleteShader(resident.ids.frag);
 		glDeleteProgram(resident.ids.main);
+		Engine::get_singleton()->notify_shader_program_released();
 	}
 	resident_programs.clear();
 }
@@ -1599,6 +1607,7 @@ Dictionary ShaderGLES3::precompile_custom_shader_variant(uint32_t p_code_id, con
 	const bool success = bound && compiled_version && compiled_version->compile_status == Version::COMPILE_STATUS_OK;
 	result["success"] = success;
 	result["already_compiled"] = already_compiled;
+	result["resident_program_count"] = Engine::get_singleton()->get_shader_resident_program_count();
 	if (compiled_version) {
 		result["program_cache_key"] = compiled_version->resident_program_key;
 		result["resident_program_hit"] = compiled_version->diagnostic_resident_program_hit;

--- a/drivers/gles3/shader_gles3.cpp
+++ b/drivers/gles3/shader_gles3.cpp
@@ -245,6 +245,9 @@ String ShaderGLES3::_diagnostic_compilation_mode() const {
 }
 
 String ShaderGLES3::_diagnostic_source(const Version *p_version) const {
+	if (p_version->diagnostic_resident_program_hit) {
+		return "resident_program";
+	}
 	switch (p_version->program_binary.source) {
 		case Version::ProgramBinary::SOURCE_LOCAL:
 			return "source";
@@ -273,6 +276,7 @@ void ShaderGLES3::_diagnostic_start(Version *p_version, const String &p_operatio
 	}
 
 	p_version->diagnostic_started_usec = OS::get_singleton()->get_ticks_usec();
+	p_version->diagnostic_operation = p_operation;
 	Engine::ShaderCompilationEvent event;
 	event.timestamp_usec = p_version->diagnostic_started_usec;
 	event.idle_frame = engine->get_idle_frames();
@@ -291,6 +295,7 @@ void ShaderGLES3::_diagnostic_start(Version *p_version, const String &p_operatio
 	event.cache_eligible = p_version->diagnostic_cache_eligible;
 	event.cache_lookup_attempted = p_version->diagnostic_cache_lookup_attempted;
 	event.cache_hit = p_version->diagnostic_cache_hit;
+	event.resident_program_hit = p_version->diagnostic_resident_program_hit;
 	event.program_cache_key = p_version->diagnostic_program_cache_key;
 	event.vertex_source_hash = p_version->diagnostic_vertex_source_hash;
 	event.fragment_source_hash = p_version->diagnostic_fragment_source_hash;
@@ -326,7 +331,7 @@ void ShaderGLES3::_diagnostic_finish(Version *p_version, bool p_success) {
 	event.custom_code_id = p_version->version_key.code_version;
 	event.custom_code_version = p_version->diagnostic_custom_code_version;
 	event.phase = "finished";
-	event.operation = p_version->program_binary.source == Version::ProgramBinary::SOURCE_CACHE ? "program_binary_load" : "compile";
+	event.operation = p_version->diagnostic_operation;
 	event.backend = "gles3";
 	event.compilation_mode = _diagnostic_compilation_mode();
 	event.source = _diagnostic_source(p_version);
@@ -336,6 +341,7 @@ void ShaderGLES3::_diagnostic_finish(Version *p_version, bool p_success) {
 	event.cache_eligible = p_version->diagnostic_cache_eligible;
 	event.cache_lookup_attempted = p_version->diagnostic_cache_lookup_attempted;
 	event.cache_hit = p_version->diagnostic_cache_hit;
+	event.resident_program_hit = p_version->diagnostic_resident_program_hit;
 	event.program_cache_key = p_version->diagnostic_program_cache_key;
 	event.vertex_source_hash = p_version->diagnostic_vertex_source_hash;
 	event.fragment_source_hash = p_version->diagnostic_fragment_source_hash;
@@ -548,6 +554,7 @@ bool ShaderGLES3::_process_program_state(Version *p_version, bool p_async_forbid
 							});
 						}
 						p_version->compile_status = Version::COMPILE_STATUS_OK;
+						p_version->shader->_retain_resident_program(p_version);
 						p_version->shader->_diagnostic_finish(p_version, true);
 						ready = true;
 					} else {
@@ -694,10 +701,13 @@ ShaderGLES3::Version *ShaderGLES3::get_current_version(bool &r_async_forbidden) 
 	v.diagnostic_fragment_source = String();
 	v.diagnostic_enabled_conditionals.clear();
 	v.diagnostic_custom_defines.clear();
+	v.diagnostic_operation = String();
+	v.resident_program_key = String();
 	v.diagnostic_debug_target = Engine::get_singleton()->is_shader_compilation_debug_target(diagnostic_material_path);
 	v.diagnostic_cache_eligible = effective_version.is_subject_to_caching();
 	v.diagnostic_cache_lookup_attempted = false;
 	v.diagnostic_cache_hit = false;
+	v.diagnostic_resident_program_hit = false;
 	v.diagnostic_started = false;
 	v.diagnostic_finished = false;
 
@@ -781,12 +791,6 @@ ShaderGLES3::Version *ShaderGLES3::get_current_version(bool &r_async_forbidden) 
 		}
 	}
 	v.diagnostic_custom_code_version = v.code_version;
-
-	/* CREATE PROGRAM */
-
-	v.ids.main = glCreateProgram();
-
-	ERR_FAIL_COND_V(v.ids.main == 0, nullptr);
 
 	// To create the ubershader we need to modify the static strings;
 	// they'll go in this array
@@ -962,8 +966,9 @@ ShaderGLES3::Version *ShaderGLES3::get_current_version(bool &r_async_forbidden) 
 		reinterpret_cast<const char *>(glGetString(GL_VERSION)),
 		nullptr,
 	};
+	v.resident_program_key = ShaderCacheGLES3::hash_program(strings_platform, strings_vertex, strings_fragment);
 	if (v.diagnostic_cache_eligible || v.diagnostic_debug_target) {
-		v.program_binary.cache_hash = ShaderCacheGLES3::hash_program(strings_platform, strings_vertex, strings_fragment);
+		v.program_binary.cache_hash = v.resident_program_key;
 		v.diagnostic_program_cache_key = v.program_binary.cache_hash;
 	}
 	if (v.diagnostic_debug_target) {
@@ -974,6 +979,17 @@ ShaderGLES3::Version *ShaderGLES3::get_current_version(bool &r_async_forbidden) 
 		v.diagnostic_vertex_source = _join_shader_source(strings_vertex);
 		v.diagnostic_fragment_source = _join_shader_source(strings_fragment);
 	}
+	if (_reuse_resident_program(&v)) {
+		if (cc) {
+			cc->versions.insert(effective_version.version);
+		}
+		_diagnostic_start(&v, "resident_program_reuse");
+		_diagnostic_finish(&v, true);
+		return &v;
+	}
+
+	v.ids.main = glCreateProgram();
+	ERR_FAIL_COND_V(v.ids.main == 0, nullptr);
 
 	bool in_cache = false;
 	if (shader_cache && v.diagnostic_cache_eligible) {
@@ -1251,6 +1267,50 @@ void ShaderGLES3::_setup_uniforms(CustomCode *p_cc) const {
 	}
 }
 
+bool ShaderGLES3::_reuse_resident_program(Version *p_version) {
+	const ResidentProgram *resident = resident_programs.getptr(p_version->resident_program_key);
+	if (!resident) {
+		return false;
+	}
+
+	p_version->ids = resident->ids;
+	p_version->program_binary.source = Version::ProgramBinary::SOURCE_NONE;
+	p_version->compile_status = Version::COMPILE_STATUS_OK;
+	p_version->uniforms_ready = false;
+	p_version->diagnostic_resident_program_hit = true;
+	return true;
+}
+
+void ShaderGLES3::_retain_resident_program(Version *p_version) {
+	ERR_FAIL_COND(p_version->resident_program_key.empty());
+
+	ResidentProgram *resident = resident_programs.getptr(p_version->resident_program_key);
+	if (resident) {
+		if (resident->ids.main != p_version->ids.main) {
+			glDeleteShader(p_version->ids.vert);
+			glDeleteShader(p_version->ids.frag);
+			glDeleteProgram(p_version->ids.main);
+			p_version->ids = resident->ids;
+		}
+		return;
+	}
+
+	ResidentProgram stored;
+	stored.ids = p_version->ids;
+	resident_programs[p_version->resident_program_key] = stored;
+}
+
+void ShaderGLES3::_free_resident_programs() {
+	const String *key = nullptr;
+	while ((key = resident_programs.next(key))) {
+		const ResidentProgram &resident = resident_programs[*key];
+		glDeleteShader(resident.ids.vert);
+		glDeleteShader(resident.ids.frag);
+		glDeleteProgram(resident.ids.main);
+	}
+	resident_programs.clear();
+}
+
 void ShaderGLES3::_dispose_program(Version *p_version) {
 	_diagnostic_finish(p_version, false);
 	if (compile_queue) {
@@ -1258,9 +1318,14 @@ void ShaderGLES3::_dispose_program(Version *p_version) {
 			compile_queue->cancel(p_version->ids.main);
 		}
 	}
-	glDeleteShader(p_version->ids.vert);
-	glDeleteShader(p_version->ids.frag);
-	glDeleteProgram(p_version->ids.main);
+	const ResidentProgram *resident = resident_programs.getptr(p_version->resident_program_key);
+	const bool is_resident = resident && resident->ids.main == p_version->ids.main;
+	if (!is_resident) {
+		glDeleteShader(p_version->ids.vert);
+		glDeleteShader(p_version->ids.frag);
+		glDeleteProgram(p_version->ids.main);
+	}
+	p_version->ids = Version::Ids();
 
 	if (p_version->compiling_list.in_list()) {
 		p_version->compiling_list.remove_from_list();
@@ -1406,6 +1471,7 @@ void ShaderGLES3::finish() {
 		_dispose_program(&v);
 		memdelete_arr(v.uniform_location);
 	}
+	_free_resident_programs();
 	ERR_FAIL_COND(versions_compiling.first());
 	ERR_FAIL_COND(active_compiles_count != 0);
 }

--- a/drivers/gles3/shader_gles3.cpp
+++ b/drivers/gles3/shader_gles3.cpp
@@ -1527,6 +1527,95 @@ void ShaderGLES3::set_custom_shader(uint32_t p_code_id, const String &p_material
 	diagnostic_material_path = p_material_path;
 }
 
+static String _shader_conditional_name(const char *p_define) {
+	String name = String(p_define).strip_edges().trim_prefix("#define").strip_edges();
+	for (int i = 0; i < name.length(); i++) {
+		if (name[i] <= 32) {
+			return name.substr(0, i);
+		}
+	}
+	return name;
+}
+
+Dictionary ShaderGLES3::precompile_custom_shader_variant(uint32_t p_code_id, const PoolStringArray &p_enabled_conditionals, const String &p_material_path) {
+	Dictionary result;
+	result["success"] = false;
+	result["shader_name"] = get_shader_name();
+	result["material_path"] = p_material_path;
+
+	CustomCode *custom_code = custom_code_map.getptr(p_code_id);
+	if (!custom_code) {
+		result["error"] = "invalid_custom_code_id";
+		return result;
+	}
+
+	PoolStringArray available_conditionals;
+	for (int i = 0; i < conditional_count; i++) {
+		available_conditionals.append(_shader_conditional_name(conditional_defines[i]));
+	}
+	result["available_conditionals"] = available_conditionals;
+
+	uint32_t requested_variant = 0;
+	PoolStringArray normalized_conditionals;
+	PoolStringArray::Read requested = p_enabled_conditionals.read();
+	for (int requested_index = 0; requested_index < p_enabled_conditionals.size(); requested_index++) {
+		String requested_name = requested[requested_index].strip_edges().trim_prefix("#define").strip_edges();
+		bool found = false;
+		for (int conditional_index = 0; conditional_index < conditional_count; conditional_index++) {
+			const String conditional_name = _shader_conditional_name(conditional_defines[conditional_index]);
+			if (requested_name == conditional_name) {
+				requested_variant |= uint32_t(1) << conditional_index;
+				normalized_conditionals.append(conditional_name);
+				found = true;
+				break;
+			}
+		}
+		if (!found) {
+			result["error"] = "unknown_conditional";
+			result["unknown_conditional"] = requested_name;
+			return result;
+		}
+	}
+
+	result["enabled_conditionals"] = normalized_conditionals;
+	result["variant"] = requested_variant;
+	result["custom_code_id"] = p_code_id;
+	result["custom_code_version"] = custom_code->version;
+
+	VersionKey requested_key;
+	requested_key.version = requested_variant;
+	requested_key.code_version = p_code_id;
+	const Version *existing = version_map.getptr(requested_key);
+	const bool already_compiled = existing && existing->code_version == custom_code->version && existing->compile_status == Version::COMPILE_STATUS_OK;
+
+	const VersionKey previous_requested_version = new_conditional_version;
+	const String previous_material_path = diagnostic_material_path;
+	if (active) {
+		active->unbind();
+	}
+	new_conditional_version = requested_key;
+	diagnostic_material_path = p_material_path;
+	const bool bound = _bind(true);
+
+	Version *compiled_version = version;
+	const bool success = bound && compiled_version && compiled_version->compile_status == Version::COMPILE_STATUS_OK;
+	result["success"] = success;
+	result["already_compiled"] = already_compiled;
+	if (compiled_version) {
+		result["program_cache_key"] = compiled_version->resident_program_key;
+		result["resident_program_hit"] = compiled_version->diagnostic_resident_program_hit;
+		result["operation"] = already_compiled ? "already_compiled" : compiled_version->diagnostic_operation;
+	}
+	if (!success) {
+		result["error"] = "shader_compilation_failed";
+	}
+
+	unbind();
+	new_conditional_version = previous_requested_version;
+	diagnostic_material_path = previous_material_path;
+	return result;
+}
+
 void ShaderGLES3::free_custom_shader(uint32_t p_code_id) {
 	ERR_FAIL_COND(!custom_code_map.has(p_code_id));
 	if (conditional_version.code_version == p_code_id) {

--- a/drivers/gles3/shader_gles3.h
+++ b/drivers/gles3/shader_gles3.h
@@ -188,10 +188,13 @@ private:
 		String diagnostic_fragment_source;
 		Vector<String> diagnostic_enabled_conditionals;
 		Vector<String> diagnostic_custom_defines;
+		String diagnostic_operation;
+		String resident_program_key;
 		bool diagnostic_debug_target;
 		bool diagnostic_cache_eligible;
 		bool diagnostic_cache_lookup_attempted;
 		bool diagnostic_cache_hit;
+		bool diagnostic_resident_program_hit;
 		bool diagnostic_started;
 		bool diagnostic_finished;
 
@@ -242,6 +245,7 @@ private:
 				diagnostic_cache_eligible(false),
 				diagnostic_cache_lookup_attempted(false),
 				diagnostic_cache_hit(false),
+				diagnostic_resident_program_hit(false),
 				diagnostic_started(false),
 				diagnostic_finished(false),
 				compile_status(COMPILE_STATUS_PENDING),
@@ -249,6 +253,13 @@ private:
 				program_binary() {}
 	};
 	static SelfList<Version>::List versions_compiling;
+
+	struct ResidentProgram {
+		Version::Ids ids;
+
+		ResidentProgram() :
+				ids() {}
+	};
 
 	Version *version;
 
@@ -258,6 +269,7 @@ private:
 
 	//this should use a way more cachefriendly version..
 	HashMap<VersionKey, Version, VersionKeyHash> version_map;
+	HashMap<String, ResidentProgram> resident_programs;
 
 	HashMap<uint32_t, CustomCode> custom_code_map;
 	uint32_t last_custom_code;
@@ -301,6 +313,9 @@ private:
 	static bool _process_program_state(Version *p_version, bool p_async_forbidden);
 	void _setup_uniforms(CustomCode *p_cc) const;
 	void _dispose_program(Version *p_version);
+	bool _reuse_resident_program(Version *p_version);
+	void _retain_resident_program(Version *p_version);
+	void _free_resident_programs();
 
 	static ShaderGLES3 *active;
 

--- a/drivers/gles3/shader_gles3.h
+++ b/drivers/gles3/shader_gles3.h
@@ -37,6 +37,7 @@
 #include "core/math/camera_matrix.h"
 #include "core/safe_refcount.h"
 #include "core/self_list.h"
+#include "core/set.h"
 #include "core/variant.h"
 
 #include "platform_config.h"
@@ -256,9 +257,12 @@ private:
 
 	struct ResidentProgram {
 		Version::Ids ids;
+		Set<String> owners;
+		bool owner_managed;
 
 		ResidentProgram() :
-				ids() {}
+				ids(),
+				owner_managed(false) {}
 	};
 
 	Version *version;
@@ -314,7 +318,9 @@ private:
 	void _setup_uniforms(CustomCode *p_cc) const;
 	void _dispose_program(Version *p_version);
 	bool _reuse_resident_program(Version *p_version);
+	void _claim_resident_program(ResidentProgram *p_resident);
 	void _retain_resident_program(Version *p_version);
+	uint32_t _evict_resident_program(const String &p_program_key);
 	void _free_resident_programs();
 
 	static ShaderGLES3 *active;
@@ -444,6 +450,7 @@ public:
 	void set_custom_shader_code(uint32_t p_code_id, const String &p_vertex, const String &p_vertex_globals, const String &p_fragment, const String &p_light, const String &p_fragment_globals, const String &p_uniforms, const Vector<StringName> &p_texture_uniforms, const Vector<CharString> &p_custom_defines, AsyncMode p_async_mode);
 	void set_custom_shader(uint32_t p_code_id, const String &p_material_path = String());
 	Dictionary precompile_custom_shader_variant(uint32_t p_code_id, const PoolStringArray &p_enabled_conditionals, const String &p_material_path = String());
+	Dictionary release_resident_program_owner(const String &p_owner);
 	String get_public_shader_name() const { return get_shader_name(); }
 	void free_custom_shader(uint32_t p_code_id);
 	bool is_custom_code_ready_for_render(uint32_t p_code_id);

--- a/drivers/gles3/shader_gles3.h
+++ b/drivers/gles3/shader_gles3.h
@@ -443,6 +443,7 @@ public:
 	uint32_t create_custom_shader();
 	void set_custom_shader_code(uint32_t p_code_id, const String &p_vertex, const String &p_vertex_globals, const String &p_fragment, const String &p_light, const String &p_fragment_globals, const String &p_uniforms, const Vector<StringName> &p_texture_uniforms, const Vector<CharString> &p_custom_defines, AsyncMode p_async_mode);
 	void set_custom_shader(uint32_t p_code_id, const String &p_material_path = String());
+	Dictionary precompile_custom_shader_variant(uint32_t p_code_id, const PoolStringArray &p_enabled_conditionals, const String &p_material_path = String());
 	void free_custom_shader(uint32_t p_code_id);
 	bool is_custom_code_ready_for_render(uint32_t p_code_id);
 

--- a/drivers/gles3/shader_gles3.h
+++ b/drivers/gles3/shader_gles3.h
@@ -180,6 +180,18 @@ private:
 		uint64_t diagnostic_compilation_id;
 		uint64_t diagnostic_started_usec;
 		String diagnostic_material_path;
+		uint32_t diagnostic_custom_code_version;
+		String diagnostic_program_cache_key;
+		String diagnostic_vertex_source_hash;
+		String diagnostic_fragment_source_hash;
+		String diagnostic_vertex_source;
+		String diagnostic_fragment_source;
+		Vector<String> diagnostic_enabled_conditionals;
+		Vector<String> diagnostic_custom_defines;
+		bool diagnostic_debug_target;
+		bool diagnostic_cache_eligible;
+		bool diagnostic_cache_lookup_attempted;
+		bool diagnostic_cache_hit;
 		bool diagnostic_started;
 		bool diagnostic_finished;
 
@@ -225,6 +237,11 @@ private:
 				last_frame_processed(UINT64_MAX),
 				diagnostic_compilation_id(0),
 				diagnostic_started_usec(0),
+				diagnostic_custom_code_version(0),
+				diagnostic_debug_target(false),
+				diagnostic_cache_eligible(false),
+				diagnostic_cache_lookup_attempted(false),
+				diagnostic_cache_hit(false),
 				diagnostic_started(false),
 				diagnostic_finished(false),
 				compile_status(COMPILE_STATUS_PENDING),
@@ -384,6 +401,7 @@ private:
 	void _diagnostic_finish(Version *p_version, bool p_success);
 	String _diagnostic_compilation_mode() const;
 	String _diagnostic_source(const Version *p_version) const;
+	static String _join_shader_source(const LocalVector<const char *> &p_strings);
 
 protected:
 	_FORCE_INLINE_ int _get_uniform(int p_which) const;

--- a/drivers/gles3/shader_gles3.h
+++ b/drivers/gles3/shader_gles3.h
@@ -444,6 +444,7 @@ public:
 	void set_custom_shader_code(uint32_t p_code_id, const String &p_vertex, const String &p_vertex_globals, const String &p_fragment, const String &p_light, const String &p_fragment_globals, const String &p_uniforms, const Vector<StringName> &p_texture_uniforms, const Vector<CharString> &p_custom_defines, AsyncMode p_async_mode);
 	void set_custom_shader(uint32_t p_code_id, const String &p_material_path = String());
 	Dictionary precompile_custom_shader_variant(uint32_t p_code_id, const PoolStringArray &p_enabled_conditionals, const String &p_material_path = String());
+	String get_public_shader_name() const { return get_shader_name(); }
 	void free_custom_shader(uint32_t p_code_id);
 	bool is_custom_code_ready_for_render(uint32_t p_code_id);
 

--- a/drivers/gles3/shader_gles3.h
+++ b/drivers/gles3/shader_gles3.h
@@ -177,6 +177,11 @@ private:
 		Vector<GLint> texture_uniform_locations;
 		bool uniforms_ready;
 		uint64_t last_frame_processed;
+		uint64_t diagnostic_compilation_id;
+		uint64_t diagnostic_started_usec;
+		String diagnostic_material_path;
+		bool diagnostic_started;
+		bool diagnostic_finished;
 
 		enum CompileStatus {
 			COMPILE_STATUS_PENDING,
@@ -218,6 +223,10 @@ private:
 				uniform_location(nullptr),
 				uniforms_ready(false),
 				last_frame_processed(UINT64_MAX),
+				diagnostic_compilation_id(0),
+				diagnostic_started_usec(0),
+				diagnostic_started(false),
+				diagnostic_finished(false),
 				compile_status(COMPILE_STATUS_PENDING),
 				compiling_list(this),
 				program_binary() {}
@@ -235,6 +244,7 @@ private:
 
 	HashMap<uint32_t, CustomCode> custom_code_map;
 	uint32_t last_custom_code;
+	String diagnostic_material_path;
 
 	VersionKey conditional_version;
 	VersionKey new_conditional_version;
@@ -370,6 +380,10 @@ private:
 
 	bool _bind(bool p_binding_fallback);
 	bool _bind_ubershader(bool p_for_warmrup = false);
+	void _diagnostic_start(Version *p_version, const String &p_operation);
+	void _diagnostic_finish(Version *p_version, bool p_success);
+	String _diagnostic_compilation_mode() const;
+	String _diagnostic_source(const Version *p_version) const;
 
 protected:
 	_FORCE_INLINE_ int _get_uniform(int p_which) const;
@@ -395,7 +409,7 @@ public:
 
 	uint32_t create_custom_shader();
 	void set_custom_shader_code(uint32_t p_code_id, const String &p_vertex, const String &p_vertex_globals, const String &p_fragment, const String &p_light, const String &p_fragment_globals, const String &p_uniforms, const Vector<StringName> &p_texture_uniforms, const Vector<CharString> &p_custom_defines, AsyncMode p_async_mode);
-	void set_custom_shader(uint32_t p_code_id);
+	void set_custom_shader(uint32_t p_code_id, const String &p_material_path = String());
 	void free_custom_shader(uint32_t p_code_id);
 	bool is_custom_code_ready_for_render(uint32_t p_code_id);
 

--- a/scene/2d/canvas_item.cpp
+++ b/scene/2d/canvas_item.cpp
@@ -174,6 +174,10 @@ void CanvasItemMaterial::flush_changes() {
 	material_mutex.unlock();
 }
 
+void CanvasItemMaterial::_flush_shader_changes() {
+	flush_changes();
+}
+
 void CanvasItemMaterial::_queue_shader_change() {
 	material_mutex.lock();
 

--- a/scene/2d/canvas_item.h
+++ b/scene/2d/canvas_item.h
@@ -127,6 +127,7 @@ private:
 protected:
 	static void _bind_methods();
 	void _validate_property(PropertyInfo &property) const;
+	virtual void _flush_shader_changes();
 
 public:
 	void set_blend_mode(BlendMode p_blend_mode);

--- a/scene/resources/material.cpp
+++ b/scene/resources/material.cpp
@@ -75,6 +75,11 @@ int Material::get_render_priority() const {
 RID Material::get_rid() const {
 	return material;
 }
+
+void Material::_resource_path_changed() {
+	VS::get_singleton()->material_set_path(material, get_path());
+}
+
 void Material::_validate_property(PropertyInfo &property) const {
 	if (!_can_do_next_pass() && property.name == "next_pass") {
 		property.usage = 0;

--- a/scene/resources/material.cpp
+++ b/scene/resources/material.cpp
@@ -76,6 +76,14 @@ RID Material::get_rid() const {
 	return material;
 }
 
+Dictionary Material::precompile_shader_variant(const PoolStringArray &p_enabled_conditionals) {
+	// Built-in materials generate and attach their shaders lazily. Flush that
+	// work before entering the renderer so precompilation does not require a
+	// draw or a geometry instance to make the shader visible.
+	_flush_shader_changes();
+	return VS::get_singleton()->material_precompile_shader_variant(material, p_enabled_conditionals);
+}
+
 void Material::_resource_path_changed() {
 	VS::get_singleton()->material_set_path(material, get_path());
 }
@@ -92,6 +100,7 @@ void Material::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("set_render_priority", "priority"), &Material::set_render_priority);
 	ClassDB::bind_method(D_METHOD("get_render_priority"), &Material::get_render_priority);
+	ClassDB::bind_method(D_METHOD("precompile_shader_variant", "enabled_conditionals"), &Material::precompile_shader_variant);
 
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "render_priority", PROPERTY_HINT_RANGE, itos(RENDER_PRIORITY_MIN) + "," + itos(RENDER_PRIORITY_MAX) + ",1"), "set_render_priority", "get_render_priority");
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "next_pass", PROPERTY_HINT_RESOURCE_TYPE, "Material"), "set_next_pass", "get_next_pass");
@@ -1132,6 +1141,10 @@ void Material3D::flush_changes() {
 	}
 
 	material_mutex.unlock();
+}
+
+void Material3D::_flush_shader_changes() {
+	flush_changes();
 }
 
 void Material3D::_queue_shader_change() {

--- a/scene/resources/material.h
+++ b/scene/resources/material.h
@@ -52,6 +52,7 @@ protected:
 	static void _bind_methods();
 	virtual void _resource_path_changed();
 	virtual bool _can_do_next_pass() const { return false; }
+	virtual void _flush_shader_changes() {}
 
 	void _validate_property(PropertyInfo &property) const;
 
@@ -67,6 +68,7 @@ public:
 	int get_render_priority() const;
 
 	virtual RID get_rid() const;
+	Dictionary precompile_shader_variant(const PoolStringArray &p_enabled_conditionals);
 
 	virtual Shader::Mode get_shader_mode() const = 0;
 	Material();
@@ -460,6 +462,7 @@ protected:
 	static void _bind_methods();
 	void _validate_property(PropertyInfo &property) const;
 	virtual bool _can_do_next_pass() const { return true; }
+	virtual void _flush_shader_changes();
 
 	Material3D(bool p_orm = false);
 

--- a/scene/resources/material.h
+++ b/scene/resources/material.h
@@ -50,6 +50,7 @@ class Material : public Resource {
 protected:
 	_FORCE_INLINE_ RID _get_material() const { return material; }
 	static void _bind_methods();
+	virtual void _resource_path_changed();
 	virtual bool _can_do_next_pass() const { return false; }
 
 	void _validate_property(PropertyInfo &property) const;

--- a/scene/resources/particles_material.cpp
+++ b/scene/resources/particles_material.cpp
@@ -707,6 +707,10 @@ void ParticlesMaterial::flush_changes() {
 	material_mutex.unlock();
 }
 
+void ParticlesMaterial::_flush_shader_changes() {
+	flush_changes();
+}
+
 void ParticlesMaterial::_queue_shader_change() {
 	material_mutex.lock();
 

--- a/scene/resources/particles_material.h
+++ b/scene/resources/particles_material.h
@@ -249,6 +249,7 @@ private:
 protected:
 	static void _bind_methods();
 	virtual void _validate_property(PropertyInfo &property) const;
+	virtual void _flush_shader_changes();
 
 public:
 	void set_direction(Vector3 p_direction);

--- a/servers/visual/rasterizer.h
+++ b/servers/visual/rasterizer.h
@@ -262,6 +262,12 @@ public:
 	virtual void material_set_render_priority(RID p_material, int priority) = 0;
 	virtual void material_set_shader(RID p_shader_material, RID p_shader) = 0;
 	virtual RID material_get_shader(RID p_shader_material) const = 0;
+	virtual Dictionary material_precompile_shader_variant(RID p_material, const PoolStringArray &p_enabled_conditionals) {
+		Dictionary result;
+		result["success"] = false;
+		result["error"] = "unsupported_renderer";
+		return result;
+	}
 
 	virtual void material_set_param(RID p_material, const StringName &p_param, const Variant &p_value) = 0;
 	virtual Variant material_get_param(RID p_material, const StringName &p_param) const = 0;

--- a/servers/visual/rasterizer.h
+++ b/servers/visual/rasterizer.h
@@ -258,6 +258,7 @@ public:
 
 	virtual RID material_create() = 0;
 
+	virtual void material_set_path(RID p_material, const String &p_path) = 0;
 	virtual void material_set_render_priority(RID p_material, int priority) = 0;
 	virtual void material_set_shader(RID p_shader_material, RID p_shader) = 0;
 	virtual RID material_get_shader(RID p_shader_material) const = 0;

--- a/servers/visual/rasterizer.h
+++ b/servers/visual/rasterizer.h
@@ -1316,6 +1316,13 @@ public:
 		result["error"] = "unsupported_renderer";
 		return result;
 	}
+	virtual Dictionary shader_release_resident_program_owner(const String &p_owner) {
+		Dictionary result;
+		result["success"] = false;
+		result["error"] = "unsupported_renderer";
+		result["owner"] = p_owner;
+		return result;
+	}
 
 	virtual void set_boot_image(const Ref<Image> &p_image, const Color &p_color, bool p_scale, bool p_use_filter = true) = 0;
 	virtual void set_shader_time_scale(float p_scale) = 0;

--- a/servers/visual/rasterizer.h
+++ b/servers/visual/rasterizer.h
@@ -1310,6 +1310,12 @@ public:
 	virtual RasterizerStorage *get_storage() = 0;
 	virtual RasterizerCanvas *get_canvas() = 0;
 	virtual RasterizerScene *get_scene() = 0;
+	virtual Dictionary shader_precompile_internal_variant(const String &p_shader_name, const PoolStringArray &p_enabled_conditionals) {
+		Dictionary result;
+		result["success"] = false;
+		result["error"] = "unsupported_renderer";
+		return result;
+	}
 
 	virtual void set_boot_image(const Ref<Image> &p_image, const Color &p_color, bool p_scale, bool p_use_filter = true) = 0;
 	virtual void set_shader_time_scale(float p_scale) = 0;

--- a/servers/visual/visual_server_raster.cpp
+++ b/servers/visual/visual_server_raster.cpp
@@ -213,6 +213,10 @@ Dictionary VisualServerRaster::shader_precompile_internal_variant(const String &
 	return VSG::rasterizer->shader_precompile_internal_variant(p_shader_name, p_enabled_conditionals);
 }
 
+Dictionary VisualServerRaster::shader_release_resident_program_owner(const String &p_owner) {
+	return VSG::rasterizer->shader_release_resident_program_owner(p_owner);
+}
+
 bool VisualServerRaster::has_feature(Features p_feature) const {
 	return false;
 }

--- a/servers/visual/visual_server_raster.cpp
+++ b/servers/visual/visual_server_raster.cpp
@@ -209,6 +209,10 @@ void VisualServerRaster::set_shader_time_scale(float p_scale) {
 	VSG::rasterizer->set_shader_time_scale(p_scale);
 }
 
+Dictionary VisualServerRaster::shader_precompile_internal_variant(const String &p_shader_name, const PoolStringArray &p_enabled_conditionals) {
+	return VSG::rasterizer->shader_precompile_internal_variant(p_shader_name, p_enabled_conditionals);
+}
+
 bool VisualServerRaster::has_feature(Features p_feature) const {
 	return false;
 }

--- a/servers/visual/visual_server_raster.h
+++ b/servers/visual/visual_server_raster.h
@@ -212,6 +212,7 @@ public:
 
 	BIND0R(RID, material_create)
 
+	BIND2(material_set_path, RID, const String &)
 	BIND2(material_set_shader, RID, RID)
 	BIND1RC(RID, material_get_shader, RID)
 

--- a/servers/visual/visual_server_raster.h
+++ b/servers/visual/visual_server_raster.h
@@ -215,6 +215,7 @@ public:
 	BIND2(material_set_path, RID, const String &)
 	BIND2(material_set_shader, RID, RID)
 	BIND1RC(RID, material_get_shader, RID)
+	BIND2R(Dictionary, material_precompile_shader_variant, RID, const PoolStringArray &)
 
 	BIND3(material_set_param, RID, const StringName &, const Variant &)
 	BIND2RC(Variant, material_get_param, RID, const StringName &)

--- a/servers/visual/visual_server_raster.h
+++ b/servers/visual/visual_server_raster.h
@@ -208,6 +208,7 @@ public:
 
 	BIND1(set_shader_async_hidden_forbidden, bool)
 	virtual Dictionary shader_precompile_internal_variant(const String &p_shader_name, const PoolStringArray &p_enabled_conditionals);
+	virtual Dictionary shader_release_resident_program_owner(const String &p_owner);
 
 	/* COMMON MATERIAL API */
 

--- a/servers/visual/visual_server_raster.h
+++ b/servers/visual/visual_server_raster.h
@@ -207,6 +207,7 @@ public:
 	BIND2(shader_remove_custom_define, RID, const String &)
 
 	BIND1(set_shader_async_hidden_forbidden, bool)
+	virtual Dictionary shader_precompile_internal_variant(const String &p_shader_name, const PoolStringArray &p_enabled_conditionals);
 
 	/* COMMON MATERIAL API */
 

--- a/servers/visual/visual_server_wrap_mt.h
+++ b/servers/visual/visual_server_wrap_mt.h
@@ -138,6 +138,7 @@ public:
 
 	FUNCRID(material)
 
+	FUNC2(material_set_path, RID, const String &)
 	FUNC2(material_set_shader, RID, RID)
 	FUNC1RC(RID, material_get_shader, RID)
 

--- a/servers/visual/visual_server_wrap_mt.h
+++ b/servers/visual/visual_server_wrap_mt.h
@@ -134,6 +134,7 @@ public:
 
 	FUNC1(set_shader_async_hidden_forbidden, bool)
 	FUNC2R(Dictionary, shader_precompile_internal_variant, const String &, const PoolStringArray &)
+	FUNC1R(Dictionary, shader_release_resident_program_owner, const String &)
 
 	/* COMMON MATERIAL API */
 

--- a/servers/visual/visual_server_wrap_mt.h
+++ b/servers/visual/visual_server_wrap_mt.h
@@ -133,6 +133,7 @@ public:
 	FUNC2(shader_remove_custom_define, RID, const String &)
 
 	FUNC1(set_shader_async_hidden_forbidden, bool)
+	FUNC2R(Dictionary, shader_precompile_internal_variant, const String &, const PoolStringArray &)
 
 	/* COMMON MATERIAL API */
 

--- a/servers/visual/visual_server_wrap_mt.h
+++ b/servers/visual/visual_server_wrap_mt.h
@@ -141,6 +141,7 @@ public:
 	FUNC2(material_set_path, RID, const String &)
 	FUNC2(material_set_shader, RID, RID)
 	FUNC1RC(RID, material_get_shader, RID)
+	FUNC2R(Dictionary, material_precompile_shader_variant, RID, const PoolStringArray &)
 
 	FUNC3(material_set_param, RID, const StringName &, const Variant &)
 	FUNC2RC(Variant, material_get_param, RID, const StringName &)

--- a/servers/visual_server.cpp
+++ b/servers/visual_server.cpp
@@ -1910,6 +1910,7 @@ void VisualServer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_shader_async_hidden_forbidden", "forbidden"), &VisualServer::set_shader_async_hidden_forbidden);
 
 	ClassDB::bind_method(D_METHOD("material_create"), &VisualServer::material_create);
+	ClassDB::bind_method(D_METHOD("material_set_path", "material", "path"), &VisualServer::material_set_path);
 	ClassDB::bind_method(D_METHOD("material_set_shader", "shader_material", "shader"), &VisualServer::material_set_shader);
 	ClassDB::bind_method(D_METHOD("material_get_shader", "shader_material"), &VisualServer::material_get_shader);
 	ClassDB::bind_method(D_METHOD("material_set_param", "material", "parameter", "value"), &VisualServer::material_set_param);

--- a/servers/visual_server.cpp
+++ b/servers/visual_server.cpp
@@ -1908,6 +1908,7 @@ void VisualServer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("shader_set_default_texture_param", "shader", "name", "texture"), &VisualServer::shader_set_default_texture_param);
 	ClassDB::bind_method(D_METHOD("shader_get_default_texture_param", "shader", "name"), &VisualServer::shader_get_default_texture_param);
 	ClassDB::bind_method(D_METHOD("set_shader_async_hidden_forbidden", "forbidden"), &VisualServer::set_shader_async_hidden_forbidden);
+	ClassDB::bind_method(D_METHOD("shader_precompile_internal_variant", "shader_name", "enabled_conditionals"), &VisualServer::shader_precompile_internal_variant);
 
 	ClassDB::bind_method(D_METHOD("material_create"), &VisualServer::material_create);
 	ClassDB::bind_method(D_METHOD("material_set_path", "material", "path"), &VisualServer::material_set_path);

--- a/servers/visual_server.cpp
+++ b/servers/visual_server.cpp
@@ -1909,6 +1909,7 @@ void VisualServer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("shader_get_default_texture_param", "shader", "name"), &VisualServer::shader_get_default_texture_param);
 	ClassDB::bind_method(D_METHOD("set_shader_async_hidden_forbidden", "forbidden"), &VisualServer::set_shader_async_hidden_forbidden);
 	ClassDB::bind_method(D_METHOD("shader_precompile_internal_variant", "shader_name", "enabled_conditionals"), &VisualServer::shader_precompile_internal_variant);
+	ClassDB::bind_method(D_METHOD("shader_release_resident_program_owner", "owner"), &VisualServer::shader_release_resident_program_owner);
 
 	ClassDB::bind_method(D_METHOD("material_create"), &VisualServer::material_create);
 	ClassDB::bind_method(D_METHOD("material_set_path", "material", "path"), &VisualServer::material_set_path);

--- a/servers/visual_server.cpp
+++ b/servers/visual_server.cpp
@@ -1913,6 +1913,7 @@ void VisualServer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("material_set_path", "material", "path"), &VisualServer::material_set_path);
 	ClassDB::bind_method(D_METHOD("material_set_shader", "shader_material", "shader"), &VisualServer::material_set_shader);
 	ClassDB::bind_method(D_METHOD("material_get_shader", "shader_material"), &VisualServer::material_get_shader);
+	ClassDB::bind_method(D_METHOD("material_precompile_shader_variant", "material", "enabled_conditionals"), &VisualServer::material_precompile_shader_variant);
 	ClassDB::bind_method(D_METHOD("material_set_param", "material", "parameter", "value"), &VisualServer::material_set_param);
 	ClassDB::bind_method(D_METHOD("material_get_param", "material", "parameter"), &VisualServer::material_get_param);
 	ClassDB::bind_method(D_METHOD("material_get_param_default", "material", "parameter"), &VisualServer::material_get_param_default);

--- a/servers/visual_server.h
+++ b/servers/visual_server.h
@@ -221,6 +221,7 @@ public:
 	virtual void material_set_path(RID p_material, const String &p_path) = 0;
 	virtual void material_set_shader(RID p_shader_material, RID p_shader) = 0;
 	virtual RID material_get_shader(RID p_shader_material) const = 0;
+	virtual Dictionary material_precompile_shader_variant(RID p_material, const PoolStringArray &p_enabled_conditionals) = 0;
 
 	virtual void material_set_param(RID p_material, const StringName &p_param, const Variant &p_value) = 0;
 	virtual Variant material_get_param(RID p_material, const StringName &p_param) const = 0;

--- a/servers/visual_server.h
+++ b/servers/visual_server.h
@@ -208,6 +208,7 @@ public:
 	virtual void shader_remove_custom_define(RID p_shader, const String &p_define) = 0;
 
 	virtual void set_shader_async_hidden_forbidden(bool p_forbidden) = 0;
+	virtual Dictionary shader_precompile_internal_variant(const String &p_shader_name, const PoolStringArray &p_enabled_conditionals) = 0;
 
 	/* COMMON MATERIAL API */
 

--- a/servers/visual_server.h
+++ b/servers/visual_server.h
@@ -218,6 +218,7 @@ public:
 	};
 	virtual RID material_create() = 0;
 
+	virtual void material_set_path(RID p_material, const String &p_path) = 0;
 	virtual void material_set_shader(RID p_shader_material, RID p_shader) = 0;
 	virtual RID material_get_shader(RID p_shader_material) const = 0;
 

--- a/servers/visual_server.h
+++ b/servers/visual_server.h
@@ -209,6 +209,7 @@ public:
 
 	virtual void set_shader_async_hidden_forbidden(bool p_forbidden) = 0;
 	virtual Dictionary shader_precompile_internal_variant(const String &p_shader_name, const PoolStringArray &p_enabled_conditionals) = 0;
+	virtual Dictionary shader_release_resident_program_owner(const String &p_owner) = 0;
 
 	/* COMMON MATERIAL API */
 


### PR DESCRIPTION
## Summary
- record shader compilation events, generated sources, material attribution, and slow-frame correlation
- expose synchronous material variant precompilation and resident program ownership APIs
- reuse programs by generated-source identity and safely release residency by profile owner
- retain log history through rotation for focused gameplay captures

## Verification
- built the Steam-enabled editor with tools=yes and lto=full
- validated with godot.x11.opt.tools.64 3.7.dev.custom_build.79b69dbcb
- shader_variant_manifest scenario passed with owner release and rebuild coverage